### PR TITLE
Fixing CARBON-14990 - Uses sh instead of bash

### DIFF
--- a/core/org.wso2.carbon.server/src/main/java/org/wso2/carbon/server/Main.java
+++ b/core/org.wso2.carbon.server/src/main/java/org/wso2/carbon/server/Main.java
@@ -171,7 +171,7 @@ public class Main {
      */
     private static void writePID(String carbonHome) {
         byte[] bo = new byte[100];
-        String[] cmd = {"bash", "-c", "echo $PPID"};
+        String[] cmd = {"sh", "-c", "echo $PPID"};
         Process p;
         try {
             p = Runtime.getRuntime().exec(cmd);

--- a/distribution/kernel/carbon-home/bin/wso2server.sh
+++ b/distribution/kernel/carbon-home/bin/wso2server.sh
@@ -180,8 +180,8 @@ elif [ "$CMD" = "start" ]; then
     fi
   fi
   export CARBON_HOME=$CARBON_HOME
-# using nohup bash to avoid erros in solaris OS.TODO
-  nohup bash $CARBON_HOME/bin/wso2server.sh $args > /dev/null 2>&1 &
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh $CARBON_HOME/bin/wso2server.sh $args > /dev/null 2>&1 &
   exit 0
 elif [ "$CMD" = "stop" ]; then
   export CARBON_HOME=$CARBON_HOME
@@ -199,8 +199,8 @@ elif [ "$CMD" = "restart" ]; then
         process_status=$?
   done
 
-# using nohup bash to avoid erros in solaris OS.TODO
-  nohup bash $CARBON_HOME/bin/wso2server.sh $args > /dev/null 2>&1 &
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh $CARBON_HOME/bin/wso2server.sh $args > /dev/null 2>&1 &
   exit 0
 elif [ "$CMD" = "test" ]; then
     JAVACMD="exec "$JAVACMD""


### PR DESCRIPTION
Since sh is generic and points to an underlying implementation(pure sh, bash, ksh, etc) on the OS.

Related JIRA: https://wso2.org/jira/browse/CARBON-14990
