### PR TITLE
Fixing CARBON-14762 - Removed jars with incompatible licenses

### DIFF
--- a/core/javax.cache/pom.xml
+++ b/core/javax.cache/pom.xml
@@ -34,8 +34,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.osgi</groupId>

--- a/core/org.wso2.carbon.caching.core/pom.xml
+++ b/core/org.wso2.carbon.caching.core/pom.xml
@@ -39,18 +39,6 @@
             <artifactId>jsr107cache</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.infinispan.wso2</groupId>
-            <artifactId>infinispan-core</artifactId>
-        </dependency>
-        <dependency>
-           <groupId>org.jboss.marshalling.wso2</groupId>
-           <artifactId>marshalling</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.logging.wso2</groupId>
-            <artifactId>jboss-logging</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jgroups.wso2</groupId>
             <artifactId>jgroups</artifactId>
         </dependency>

--- a/core/org.wso2.carbon.core/pom.xml
+++ b/core/org.wso2.carbon.core/pom.xml
@@ -61,11 +61,6 @@
             <artifactId>bcprov-jdk15on</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.infinispan.wso2</groupId>
-            <artifactId>infinispan-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>javax.cache.wso2</artifactId>
             <version>4.3.0-SNAPSHOT</version>

--- a/core/org.wso2.carbon.registry.core/pom.xml
+++ b/core/org.wso2.carbon.registry.core/pom.xml
@@ -496,12 +496,6 @@
             <version>${orbit.version.commons.pool}</version>
         </dependency>
         <dependency>
-            <groupId>org.infinispan.wso2</groupId>
-            <artifactId>infinispan-core</artifactId>
-            <version>${orbit.version.infinispan}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>net.sf.ehcache.wso2</groupId>
             <artifactId>ehcache</artifactId>
             <version>${version.ehcache}</version>

--- a/core/org.wso2.carbon.server/src/assembly/bin.xml
+++ b/core/org.wso2.carbon.server/src/assembly/bin.xml
@@ -35,9 +35,8 @@
                 <include>xalan.wso2:xalan:jar</include>
                 <include>xml-apis.wso2:xml-apis:jar</include>
                 <include>org.apache.geronimo.specs:geronimo-jaxws_2.2_spec:jar</include>
+                <include>org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar</include>
                 <include>org.apache.geronimo.specs.wso2:geronimo-jms_1.1_spec:jar</include>
-                <include>org.jboss.javaee:jboss-transaction-api:jar</include>
-                <include>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar</include>
             </includes>
         </dependencySet>
         <dependencySet>

--- a/distribution/kernel/carbon-home/bin/build.xml
+++ b/distribution/kernel/carbon-home/bin/build.xml
@@ -36,7 +36,6 @@
                 <include name="axis2*.jar"/>
                 <include name="axiom*.jar"/>
                 <include name="jgroups*.jar"/>
-                <include name="jboss-logging*.jar"/>
                 <include name="woden*.jar"/>
                 <include name="wsdl4j*.jar"/>
                 <include name="xerces*.jar"/>
@@ -51,7 +50,6 @@
                 <include name="rampart-policy*.jar"/>
                 <include name="rampart-core*.jar"/>
                 <include name="wss4j*.jar"/>
-                <include name="infinispan-core*.jar"/>
                 <include name="httpcore*.jar"/>
                 <include name="org.wso2.carbon.core*.jar"/>
                 <include name="org.wso2.carbon.utils*.jar"/>

--- a/distribution/kernel/pom.xml
+++ b/distribution/kernel/pom.xml
@@ -123,9 +123,8 @@
             <artifactId>xml-apis</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.transaction</groupId>
-            <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-            <version>1.0.0.Final</version>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jta_1.1_spec</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>

--- a/distribution/kernel/src/assembly/bin.xml
+++ b/distribution/kernel/src/assembly/bin.xml
@@ -128,7 +128,7 @@
                 <include>xml-apis.wso2:xml-apis:jar</include>
                 <include>org.apache.geronimo.specs:geronimo-jaxws_2.2_spec:jar</include>
                 <include>org.apache.geronimo.specs.wso2:geronimo-jms_1.1_spec:jar</include>
-                <include>org.jboss.spec.javax.transaction:jboss-transaction-api_1.1_spec:jar</include>
+                <include>org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar</include>
                 <include>org.apache.tomcat:tomcat-annotations-api:jar</include>
             </includes>
         </dependencySet>

--- a/features/org.wso2.carbon.core.common.feature/pom.xml
+++ b/features/org.wso2.carbon.core.common.feature/pom.xml
@@ -89,9 +89,6 @@
                                 <bundleDef>org.wso2.carbon:org.wso2.carbon.ndatasource.rdbms</bundleDef>
 				<bundleDef>org.wso2.carbon:org.wso2.carbon.user.api</bundleDef>
                                 <bundleDef>net.sf.jsr107cache.wso2:jsr107cache:1.1.0.wso2v3</bundleDef>
-                                <bundleDef>org.jboss.marshalling.wso2:marshalling:1.3.6.wso2v1</bundleDef>
-                                <bundleDef>org.infinispan.wso2:infinispan-core:5.1.2.wso2v1</bundleDef>
-                                <bundleDef>org.jboss.logging.wso2:jboss-logging:3.1.0.wso2v1</bundleDef>
                                 <bundleDef>org.jgroups.wso2:jgroups:3.0.6.wso2v1</bundleDef>
 			        <bundleDef>au.com.bytecode.opencsv.wso2:opencsv:1.8.wso2v1</bundleDef>
 				<bundleDef>org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2</bundleDef>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -305,7 +305,7 @@
         <version.geronimo.saaj.spec>1.0.0.wso2v3</version.geronimo.saaj.spec>
         <version.geronimo.jms.spec>1.1.0.wso2v1</version.geronimo.jms.spec>
         <version.geronimo.stax.spec>1.0.1.wso2v1</version.geronimo.stax.spec>
-        <version.geronimo.jta.spec>1.1.0.wso2v1</version.geronimo.jta.spec>
+        <version.geronimo.jta.spec>1.1</version.geronimo.jta.spec>
         <version.geronimo.jaxws.spec>1.0</version.geronimo.jaxws.spec>
         <version.woodstox.core.asl>4.2.0</version.woodstox.core.asl>
         <version.stax2.api>3.1.1</version.stax2.api>
@@ -342,21 +342,6 @@
         <exp.pkg.version.spring>3.1.0.wso2v2</exp.pkg.version.spring>
         <imp.pkg.version.spring>[3.1.0.wso2v2, 3.2.0)</imp.pkg.version.spring>
         <version.spring>3.1.0.RELEASE</version.spring>
-
-        <!--Infinispan-->
-        <orbit.version.infinispan>5.1.2.wso2v1</orbit.version.infinispan>
-        <exp.pkg.version.infinispan>5.1.2.wso2v1</exp.pkg.version.infinispan>
-        <imp.pkg.version.infinispan>[5.1.2.wso2v1, 5.2.0)</imp.pkg.version.infinispan>
-
-        <!--JBoss Logging-->
-        <orbit.version.jboss.logging>3.1.0.wso2v1</orbit.version.jboss.logging>
-        <exp.pkg.version.jboss.logging>3.1.0.wso2v1</exp.pkg.version.jboss.logging>
-        <imp.pkg.version.jboss.logging>[3.1.0.wso2v1, 3.2.0)</imp.pkg.version.jboss.logging>
-
-        <!--Jboss marshalling-->
-        <orbit.version.marshalling>1.3.6.wso2v1</orbit.version.marshalling>
-        <exp.pkg.version.marshalling>1.3.6.wso2v1</exp.pkg.version.marshalling>
-        <imp.pkg.version.marshalling>[1.3.6.wso2v1, 1.4.0)</imp.pkg.version.marshalling>
 
         <!--JGroups-->
         <orbit.version.jgroups>3.0.6.wso2v1</orbit.version.jgroups>
@@ -455,9 +440,6 @@
         <version.opensaml2>2.4.1.wso2v1</version.opensaml2>
         <version.compass>2.0.1.wso2v2</version.compass>
         <version.jsr107cache>1.1.0-wso2v2</version.jsr107cache>
-
-        <!-- jboss transaction api -->
-        <version.jboss.transaction.spec>1.0.0.Final</version.jboss.transaction.spec>
 
         <version.xercesImpl>2.8.1.wso2v2</version.xercesImpl>
         <version.xalan>2.7.1.wso2v1</version.xalan>
@@ -861,29 +843,9 @@
                 <version>${version.jsr107cache}</version>
             </dependency>
             <dependency>
-                <groupId>org.infinispan.wso2</groupId>
-                <artifactId>infinispan-core</artifactId>
-                <version>${orbit.version.infinispan}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.marshalling.wso2</groupId>
-                <artifactId>marshalling</artifactId>
-                <version>${orbit.version.marshalling}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.logging.wso2</groupId>
-                <artifactId>jboss-logging</artifactId>
-                <version>${orbit.version.jboss.logging}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jgroups.wso2</groupId>
                 <artifactId>jgroups</artifactId>
                 <version>${orbit.version.jgroups}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.spec.javax.transaction</groupId>
-                <artifactId>jboss-transaction-api_1.1_spec</artifactId>
-                <version>${version.jboss.transaction.spec}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.axis2.wso2</groupId>
@@ -1063,7 +1025,7 @@
                 <version>version.authenticator</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.geronimo.specs.wso2</groupId>
+                <groupId>org.apache.geronimo.specs</groupId>
                 <artifactId>geronimo-jta_1.1_spec</artifactId>
                 <version>${version.geronimo.jta.spec}</version>
             </dependency>


### PR DESCRIPTION
Removed infinispan-core_5.2.1, jboss-logging_3.1.0, jboss-transaction-api_1.1_spec-1.0.0, marshalling_1.3.6 and added geronimo-jta_1.1_spec.
