### PR TITLE
Handle NPE

### DIFF
--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/deployment/GhostDeployer.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/deployment/GhostDeployer.java
@@ -130,13 +130,14 @@ public class GhostDeployer extends AbstractDeployer {
                 if (CarbonUtils.isFilteredOutService(service)) {
                     continue;
                 }
-                tempAbsolutePath = GhostDeployer.separatorsToUnix(absoluteFilePath);
-                File serviceFilePathUrlToFile = new File(service.getFileName().getPath());
-                String serviceFilePathUrlToFileAbsolutePath = serviceFilePathUrlToFile.getAbsolutePath();
-                String serviceFileAbsolutePathToUnix = GhostDeployer.separatorsToUnix(serviceFilePathUrlToFileAbsolutePath);
+                if (service.getFileName() != null) {
+                    tempAbsolutePath = GhostDeployer.separatorsToUnix(absoluteFilePath);
+                    File serviceFilePathUrlToFile = new File(service.getFileName().getPath());
+                    String serviceFilePathUrlToFileAbsolutePath = serviceFilePathUrlToFile.getAbsolutePath();
+                    String serviceFileAbsolutePathToUnix = GhostDeployer.separatorsToUnix(serviceFilePathUrlToFileAbsolutePath);
 
-                if (service.getFileName() != null && serviceFileAbsolutePathToUnix
-                        .equals(tempAbsolutePath)) {
+                    if (serviceFileAbsolutePathToUnix
+                            .equals(tempAbsolutePath)) {
                     GhostDeployerUtils.updateLastUsedTime(service);
                     try {
                         //skip ghost metafile generation for worker nodes.
@@ -150,6 +151,7 @@ public class GhostDeployer extends AbstractDeployer {
                     }
                     break;
                 }
+            }
             }
         } else {
             // load the ghost service group


### PR DESCRIPTION
NullPointer Exception thrown when using GD in ESB, AS-6.0.0 (mgtconsole not loaded) due to GAppTenant Axis2service getfilename() returns null.
The earlier patches also had the same issue, yet NP was not thrown as they had the check condition as
if (service.getFileName() != null && service.getFileName().getPath()
.equals(absoluteFilePath)) {

Since, I did
File serviceFilePathUrlToFile = new File(service.getFileName().getPath());
check before checking for NP, the exception got thrown by the JVM.
Now it is handled as in the updated diff
