### PR TITLE
CARBON-15115: Initial version of org.wso2.carbon.metrics API.

### DIFF
--- a/core/org.wso2.carbon.metrics.impl/pom.xml
+++ b/core/org.wso2.carbon.metrics.impl/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    # Copyright 2014 WSO2 Inc. (http://wso2.org)
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    # http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+
+    <parent>
+        <groupId>org.wso2.carbon</groupId>
+        <artifactId>carbon-kernel</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.metrics.impl</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Metrics Implementation</name>
+    <repositories>
+        <repository>
+            <id>wso2-nexus</id>
+            <name>WSO2 internal Repository</name>
+            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>fail</checksumPolicy>
+            </releases>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.metrics.manager</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${metrics.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ws.commons.axiom.wso2</groupId>
+            <artifactId>axiom</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io.wso2</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.securevault</artifactId>
+            <version>${carbon.platform.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+            <version>${carbon.platform.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.metrics.impl.internal
+                        </Private-Package>
+                        <Export-Package>
+                            org.wso2.carbon.metrics.impl.*,
+                        </Export-Package>
+                        <Import-Package>
+                            org.wso2.carbon.metrics.manager.*,
+                            com.codahale.metrics;
+                            version="${metrics.version.range}
+                        </Import-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <properties>
+        <metrics.version>3.1.0</metrics.version>
+        <metrics.version.range>[3.1.0, 4.0.0)</metrics.version.range>
+    </properties>
+</project>

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/AbstractMetric.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/AbstractMetric.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.Observable;
+import java.util.Observer;
+
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.Metric;
+
+/**
+ * An abstract class to keep generic behavior for metric instances. This class implements {@link Observer} interface and
+ * takes part in observer pattern to update the enabled flag
+ */
+public abstract class AbstractMetric implements Observer, Metric {
+
+    /**
+     * A flag to indicate whether the metric is enabled
+     */
+    private boolean enabled;
+
+    /**
+     * The level used when creating the metric
+     */
+    private final Level level;
+
+    public AbstractMetric(Level level) {
+        this.level = level;
+    }
+
+    protected final boolean isEnabled() {
+        return enabled;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.util.Observer#update(java.util.Observable, java.lang.Object)
+     */
+    @Override
+    public void update(Observable o, Object arg) {
+        Level newLevel = (Level) arg;
+        setEnabled(newLevel);
+    }
+
+    public void setEnabled(Level newLevel) {
+        // Enable if the new threshold level is greater than or equal to current level.
+        // This should be done only if the new level is not equal to OFF.
+        // Otherwise the condition would fail when comparing two "OFF" levels
+        enabled = newLevel.intLevel() >= level.intLevel() && newLevel.intLevel() > Level.OFF.intLevel();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/CachedGaugeImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/CachedGaugeImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.concurrent.TimeUnit;
+
+import org.wso2.carbon.metrics.manager.Gauge;
+import org.wso2.carbon.metrics.manager.Level;
+
+import com.codahale.metrics.CachedGauge;
+
+/**
+ * Implementation of cached {@link Gauge} metric
+ */
+public class CachedGaugeImpl<T> extends AbstractMetric implements com.codahale.metrics.Gauge<T> {
+
+    private CachedGauge<T> gauge;
+
+    public CachedGaugeImpl(Level level, long timeout, TimeUnit timeoutUnit, final Gauge<T> gauge) {
+        super(level);
+        this.gauge = new CachedGauge<T>(timeout, timeoutUnit) {
+            @Override
+            protected T loadValue() {
+                return gauge.getValue();
+            }
+        };
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.codahale.metrics.Gauge#getValue()
+     */
+    @Override
+    public T getValue() {
+        if (isEnabled()) {
+            return gauge.getValue();
+        }
+        return null;
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/CounterImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/CounterImpl.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import org.wso2.carbon.metrics.manager.Level;
+
+import com.codahale.metrics.Counter;
+
+/**
+ * Implementation class wrapping {@link Counter} metric
+ */
+public class CounterImpl extends AbstractMetric implements org.wso2.carbon.metrics.manager.Counter {
+
+    private Counter counter;
+
+    public CounterImpl(Level level, Counter counter) {
+        super(level);
+        this.counter = counter;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Counter#inc()
+     */
+    @Override
+    public void inc() {
+        if (isEnabled()) {
+            counter.inc();
+        }
+
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Counter#inc(long)
+     */
+    @Override
+    public void inc(long n) {
+        if (isEnabled()) {
+            counter.inc(n);
+        }
+
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Counter#dec()
+     */
+    @Override
+    public void dec() {
+        if (isEnabled()) {
+            counter.dec();
+        }
+
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Counter#dec(long)
+     */
+    @Override
+    public void dec(long n) {
+        if (isEnabled()) {
+            counter.dec(n);
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Counter#getCount()
+     */
+    @Override
+    public long getCount() {
+        return counter.getCount();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/GaugeImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/GaugeImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import org.wso2.carbon.metrics.manager.Gauge;
+import org.wso2.carbon.metrics.manager.Level;
+
+/**
+ * Implementation of {@link Gauge} metric
+ */
+public class GaugeImpl<T> extends AbstractMetric implements com.codahale.metrics.Gauge<T> {
+
+    private Gauge<T> gauge;
+
+    public GaugeImpl(Level level, Gauge<T> gauge) {
+        super(level);
+        this.gauge = gauge;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see com.codahale.metrics.Gauge#getValue()
+     */
+    @Override
+    public T getValue() {
+        if (isEnabled()) {
+            return gauge.getValue();
+        }
+        return null;
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/HistogramImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/HistogramImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import org.wso2.carbon.metrics.manager.Level;
+
+import com.codahale.metrics.Histogram;
+
+/**
+ * Implementation class wrapping {@link Histogram} metric
+ */
+public class HistogramImpl extends AbstractMetric implements org.wso2.carbon.metrics.manager.Histogram {
+
+    private Histogram histogram;
+
+    public HistogramImpl(Level level, Histogram histogram) {
+        super(level);
+        this.histogram = histogram;
+    }
+
+    /*
+     * @see org.wso2.carbon.metrics.manager.Histogram#update(int)
+     */
+    @Override
+    public void update(int value) {
+        if (isEnabled()) {
+            histogram.update(value);
+        }
+    }
+
+    /*
+     * @see org.wso2.carbon.metrics.manager.Histogram#update(long)
+     */
+    @Override
+    public void update(long value) {
+        if (isEnabled()) {
+            histogram.update(value);
+        }
+    }
+
+    /*
+     * @see org.wso2.carbon.metrics.manager.Histogram#getCount()
+     */
+    @Override
+    public long getCount() {
+        return histogram.getCount();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MeterImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MeterImpl.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import org.wso2.carbon.metrics.manager.Level;
+
+import com.codahale.metrics.Meter;
+
+/**
+ * Implementation class wrapping {@link Meter} metric
+ */
+public class MeterImpl extends AbstractMetric implements org.wso2.carbon.metrics.manager.Meter {
+
+    private Meter meter;
+
+    public MeterImpl(Level level, Meter meter) {
+        super(level);
+        this.meter = meter;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Meter#mark()
+     */
+    @Override
+    public void mark() {
+        if (isEnabled()) {
+            meter.mark();
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Meter#mark(long)
+     */
+    @Override
+    public void mark(long n) {
+        if (isEnabled()) {
+            meter.mark(n);
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Meter#getCount()
+     */
+    @Override
+    public long getCount() {
+        return meter.getCount();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MetricServiceImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MetricServiceImpl.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Observable;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.metrics.manager.Counter;
+import org.wso2.carbon.metrics.manager.Gauge;
+import org.wso2.carbon.metrics.manager.Histogram;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.Meter;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.Timer;
+
+import com.codahale.metrics.CsvReporter;
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.MetricRegistry;
+
+/**
+ * Implementation class for {@link MetricService}, which will use the Metrics (https://dropwizard.github.io/metrics)
+ * library. This is registered as an OSGi service
+ */
+public class MetricServiceImpl extends Observable implements MetricService {
+
+    private static final Log log = LogFactory.getLog(MetricServiceImpl.class);
+
+    /**
+     * The level configured for Metrics collection
+     */
+    private Level level;
+
+    /**
+     * The previous level to identify changes in level configuration
+     */
+    private Level previousLevel;
+
+    /**
+     * The {@link MetricRegistry} instance from the Metrics Implementation
+     */
+    private final MetricRegistry metricRegistry;
+
+    private static final String JMX_REPORTING_ENABLED = "Reporting.JMX.Enabled";
+    private static final String CSV_REPORTING_ENABLED = "Reporting.CSV.Enabled";
+    private static final String CSV_REPORTING_LOCATION = "Reporting.CSV.Location";
+    private static final String CSV_REPORTING_POLLING_PERIOD = "Reporting.CSV.PollingPeriod";
+
+    /**
+     * JMX domain registered with MBean Server
+     */
+    private static final String JMX_REPORTING_DOMAIN = "org.wso2.carbon.metrics";
+
+    private final List<Reporter> reporters = new ArrayList<Reporter>();
+
+    /**
+     * Initialize the MetricRegistry, Level and Reporters
+     */
+    public MetricServiceImpl(Level level) {
+        metricRegistry = new MetricRegistry();
+        Reporter jmxReporter = null;
+        try {
+            jmxReporter = configureJMXReporter();
+        } catch (Throwable e) {
+            log.error("Error when configuring JMX reporter", e);
+        }
+
+        if (jmxReporter != null) {
+            reporters.add(jmxReporter);
+        }
+
+        Reporter csvReporter = null;
+        try {
+            csvReporter = configureCSVReporter();
+        } catch (Throwable e) {
+            log.error("Error when configuring CSV reporter", e);
+        }
+
+        if (csvReporter != null) {
+            reporters.add(csvReporter);
+        }
+
+        // Initial level
+        this.level = Level.OFF;
+        setLevel(level);
+    }
+
+    public Level getLevel() {
+        return level;
+    }
+
+    public void setLevel(Level level) {
+        this.previousLevel = this.level;
+        this.level = level;
+        boolean changed = !this.level.equals(this.previousLevel);
+        if (changed) {
+            setChanged();
+            notifyObservers(level);
+            if (this.level.compareTo(Level.OFF) > 0) {
+                startReporters();
+            } else if (this.level.equals(Level.OFF)) {
+                stopReporters();
+            }
+        }
+    }
+
+    public int getObserverCount() {
+        // This count may not be always equal to the actual number of metrics used in the system. The Metrics
+        // implementation keeps a map based on the metric name. Hence if a user retrieves the same metric type with
+        // existing name, this service will wrap an existing metric instance and add as an observer.
+        return countObservers();
+    }
+
+    public int getMetricsCount() {
+        return metricRegistry.getMetrics().size();
+    }
+
+    public Meter createMeter(Level level, String name) {
+        MeterImpl meter = new MeterImpl(level, metricRegistry.meter(name));
+        meter.setEnabled(getLevel());
+        addObserver(meter);
+        return meter;
+    }
+
+    public Counter createCounter(Level level, String name) {
+        CounterImpl counter = new CounterImpl(level, metricRegistry.counter(name));
+        counter.setEnabled(getLevel());
+        addObserver(counter);
+        return counter;
+    }
+
+    public Timer createTimer(Level level, String name) {
+        TimerImpl timer = new TimerImpl(level, metricRegistry.timer(name));
+        timer.setEnabled(getLevel());
+        addObserver(timer);
+        return timer;
+    }
+
+    public Histogram createHistogram(Level level, String name) {
+        HistogramImpl histogram = new HistogramImpl(level, metricRegistry.histogram(name));
+        histogram.setEnabled(getLevel());
+        addObserver(histogram);
+        return histogram;
+    }
+
+    public <T> void createGauge(Level level, String name, Gauge<T> gauge) {
+        GaugeImpl<T> gaugeImpl = new GaugeImpl<T>(level, gauge);
+        gaugeImpl.setEnabled(getLevel());
+        addObserver(gaugeImpl);
+        metricRegistry.register(name, gaugeImpl);
+    }
+    
+    public <T> void createCachedGauge(Level level, String name, long timeout, TimeUnit timeoutUnit, Gauge<T> gauge) {
+        CachedGaugeImpl<T> gaugeImpl = new CachedGaugeImpl<T>(level, timeout, timeoutUnit, gauge);
+        gaugeImpl.setEnabled(getLevel());
+        addObserver(gaugeImpl);
+        metricRegistry.register(name, gaugeImpl);
+    }
+
+    /**
+     * Reporter interface to manage multiple reporters in this service
+     */
+    private interface Reporter {
+        void start();
+
+        boolean isRunning();
+
+        void stop();
+    }
+
+    private class JmxReporterImpl implements Reporter {
+
+        private final JmxReporter jmxReporter;
+
+        private boolean running;
+
+        public JmxReporterImpl(JmxReporter jmxReporter) {
+            this.jmxReporter = jmxReporter;
+        }
+
+        @Override
+        public void start() {
+            jmxReporter.start();
+            running = true;
+            if (log.isInfoEnabled()) {
+                log.info("Started JMX reporter for Metrics");
+            }
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public void stop() {
+            jmxReporter.stop();
+            running = false;
+            if (log.isInfoEnabled()) {
+                log.info("Stopped JMX reporter for Metrics");
+            }
+        }
+    }
+
+    private class CsvReporterImpl implements Reporter {
+
+        private final CsvReporter csvReporter;
+
+        private final long pollingPeriod;
+
+        private boolean running;
+
+        public CsvReporterImpl(CsvReporter csvReporter, long pollingPeriod) {
+            this.csvReporter = csvReporter;
+            this.pollingPeriod = pollingPeriod;
+        }
+
+        @Override
+        public void start() {
+            csvReporter.start(pollingPeriod, TimeUnit.SECONDS);
+
+            running = true;
+            if (log.isInfoEnabled()) {
+                log.info(String.format("Started CSV reporter for Metrics with %d seconds polling period.",
+                        pollingPeriod));
+            }
+        }
+
+        @Override
+        public boolean isRunning() {
+            return running;
+        }
+
+        @Override
+        public void stop() {
+            csvReporter.stop();
+            running = false;
+            if (log.isInfoEnabled()) {
+                log.info("Stopped CSV reporter for Metrics");
+            }
+        }
+    }
+
+    private void startReporters() {
+        for (Reporter reporter : reporters) {
+            if (!reporter.isRunning()) {
+                reporter.start();
+            }
+        }
+    }
+
+    private void stopReporters() {
+        for (Reporter reporter : reporters) {
+            if (reporter.isRunning()) {
+                reporter.stop();
+            }
+        }
+    }
+
+    private Reporter configureJMXReporter() {
+        MetricsConfiguration metricsConfiguration = MetricsConfiguration.getInstance();
+        if (!Boolean.parseBoolean(metricsConfiguration.getFirstProperty(JMX_REPORTING_ENABLED))) {
+            if (log.isDebugEnabled()) {
+                log.debug("JMX Reporting for Metrics is not enabled");
+            }
+            return null;
+        }
+        final JmxReporter jmxReporter = JmxReporter.forRegistry(metricRegistry).inDomain(JMX_REPORTING_DOMAIN)
+                .convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.MILLISECONDS).build();
+        return new JmxReporterImpl(jmxReporter);
+    }
+
+    private Reporter configureCSVReporter() {
+        MetricsConfiguration metricsConfiguration = MetricsConfiguration.getInstance();
+        if (!Boolean.parseBoolean(metricsConfiguration.getFirstProperty(CSV_REPORTING_ENABLED))) {
+            if (log.isDebugEnabled()) {
+                log.debug("CSV Reporting for Metrics is not enabled");
+            }
+            return null;
+        }
+        String location = metricsConfiguration.getFirstProperty(CSV_REPORTING_LOCATION);
+        if (location == null || location.trim().isEmpty()) {
+            if (log.isWarnEnabled()) {
+                log.warn("CSV Reporting location is not specified");
+            }
+            return null;
+        }
+        File file = new File(location);
+        if (!file.exists()) {
+            if (!file.mkdir()) {
+                if (log.isWarnEnabled()) {
+                    log.warn("CSV Reporting location was not created!");
+                }
+                return null;
+            }
+        }
+        if (!file.isDirectory()) {
+            if (log.isWarnEnabled()) {
+                log.warn("CSV Reporting location is not a directory");
+            }
+            return null;
+        }
+        String pollingPeriod = metricsConfiguration.getFirstProperty(CSV_REPORTING_POLLING_PERIOD);
+        // Default polling period for CSV reporter is 60 seconds
+        long csvReporterPollingPeriod = 60;
+        try {
+            csvReporterPollingPeriod = Long.parseLong(pollingPeriod);
+        } catch (NumberFormatException e) {
+            if (log.isWarnEnabled()) {
+                log.warn(String.format("Error parsing the polling period for CSV Reporting. Using %d seconds",
+                        csvReporterPollingPeriod));
+            }
+        }
+        if (log.isInfoEnabled()) {
+            log.info(String.format("Creating CSV reporter for Metrics with location: %s", location));
+        }
+
+        final CsvReporter csvReporter = CsvReporter.forRegistry(metricRegistry).formatFor(Locale.US)
+                .convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.MILLISECONDS).build(file);
+        return new CsvReporterImpl(csvReporter, csvReporterPollingPeriod);
+    }
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MetricsConfigException.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MetricsConfigException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+/**
+ * Exception class for Metrics Configuration
+ */
+public class MetricsConfigException extends Exception {
+
+    private static final long serialVersionUID = 3625949980553494713L;
+
+    public MetricsConfigException() {
+        super();
+    }
+
+    public MetricsConfigException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MetricsConfigException(String message) {
+        super(message);
+    }
+
+    public MetricsConfigException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MetricsConfiguration.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/MetricsConfiguration.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMException;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.securevault.SecretResolver;
+import org.wso2.securevault.SecretResolverFactory;
+
+/**
+ * Global Configuration Reader for Metrics
+ */
+public class MetricsConfiguration {
+
+    private static final Log log = LogFactory.getLog(MetricsConfiguration.class);
+
+    private static final MetricsConfiguration INSTANCE = new MetricsConfiguration();
+
+    private Map<String, List<String>> configurationMap = new ConcurrentHashMap<String, List<String>>();
+
+    private SecretResolver secretResolver;
+
+    /**
+     * Flag to check whether the configuration was initialized
+     */
+    private boolean initialized;
+
+    /**
+     * The regex pattern to identify a system property
+     */
+    private static final Pattern SYSTEM_PROPERTY_PATTERN;
+
+    static {
+        SYSTEM_PROPERTY_PATTERN = Pattern.compile("\\$\\{([\\w\\.]*)\\}");
+    }
+
+    public static MetricsConfiguration getInstance() {
+        return INSTANCE;
+    }
+
+    private MetricsConfiguration() {
+    }
+
+    /**
+     * Load Metrics related configurations by reading an XML file.
+     *
+     * @param filePath Path of the XML file
+     * @throws MetricsConfigException If an error occurs while reading the XML configuration
+     */
+    public void load(String filePath) throws MetricsConfigException {
+        if (initialized) {
+            return;
+        }
+        InputStream in = null;
+        try {
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("Loading Metrics Configuration from %s", filePath));
+            }
+            in = FileUtils.openInputStream(new File(filePath));
+            StAXOMBuilder builder = new StAXOMBuilder(in);
+            secretResolver = SecretResolverFactory.create(builder.getDocumentElement(), true);
+            readChildElements(builder.getDocumentElement(), new Stack<String>());
+            initialized = true;
+        } catch (IOException e) {
+            throw new MetricsConfigException("I/O error while reading the configuration file: " + filePath, e);
+        } catch (XMLStreamException e) {
+            throw new MetricsConfigException("Error while parsing the configuration file: " + filePath, e);
+        } catch (OMException e) {
+            throw new MetricsConfigException("Error while parsing the configuration file: " + filePath, e);
+        } catch (Exception e) {
+            throw new MetricsConfigException("Unexpected error occurred while parsing configuration: " + filePath, e);
+        } finally {
+            IOUtils.closeQuietly(in);
+        }
+    }
+
+    public String getFirstProperty(String key) {
+        List<String> value = configurationMap.get(key);
+        if (value == null) {
+            return null;
+        }
+        return value.get(0);
+    }
+
+    public List<String> getProperty(String key) {
+        return configurationMap.get(key);
+    }
+
+    private void readChildElements(OMElement serverConfig, Stack<String> nameStack) {
+        for (Iterator<?> childElements = serverConfig.getChildElements(); childElements.hasNext();) {
+            OMElement element = (OMElement) childElements.next();
+            String localName = element.getLocalName();
+            nameStack.push(localName);
+            if (elementHasText(element)) {
+                String key = getKey(nameStack);
+                String value = element.getText();
+                if (secretResolver.isInitialized() && secretResolver.isTokenProtected(key)) {
+                    value = secretResolver.resolve(key);
+                }
+                addToConfiguration(key, replaceSystemProperties(value));
+            }
+            readChildElements(element, nameStack);
+            nameStack.pop();
+        }
+    }
+
+    private String getKey(Stack<String> nameStack) {
+        StringBuilder key = new StringBuilder();
+        for (int i = 0; i < nameStack.size(); i++) {
+            String name = nameStack.elementAt(i);
+            key.append(name).append(".");
+        }
+        key.deleteCharAt(key.lastIndexOf("."));
+
+        return key.toString();
+    }
+
+    private boolean elementHasText(OMElement element) {
+        String text = element.getText();
+        return text != null && text.trim().length() > 0;
+    }
+
+    private void addToConfiguration(String key, String value) {
+        if (log.isTraceEnabled()) {
+            log.trace(String.format("Adding configuration '%s' with value '%s'", key, value));
+        }
+        List<String> list = configurationMap.get(key);
+        if (list == null) {
+            list = new ArrayList<String>();
+            list.add(value);
+            configurationMap.put(key, list);
+        } else {
+            list.add(value);
+        }
+    }
+
+    public static String replaceSystemProperties(String text) {
+        Matcher matcher = SYSTEM_PROPERTY_PATTERN.matcher(text);
+        boolean found = matcher.find();
+        if (!found) {
+            return text;
+        }
+        StringBuffer sb = new StringBuffer();
+        do {
+            String name = matcher.group(1);
+            String value = System.getProperty(name);
+            if (value != null) {
+                matcher.appendReplacement(sb, value);
+            }
+        } while (matcher.find());
+        matcher.appendTail(sb);
+        String replaced = sb.toString();
+        if (log.isDebugEnabled()) {
+            log.debug(String.format("Replaced. Old: '%s', New: '%s'", text, replaced));
+        }
+        return replaced;
+    }
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/TimerImpl.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/TimerImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.wso2.carbon.metrics.manager.Level;
+
+import com.codahale.metrics.Timer;
+
+/**
+ * Implementation class wrapping {@link Timer} metric
+ */
+public class TimerImpl extends AbstractMetric implements org.wso2.carbon.metrics.manager.Timer {
+
+    private Timer timer;
+
+    public TimerImpl(Level level, Timer timer) {
+        super(level);
+        this.timer = timer;
+    }
+
+    private static class ContextImpl implements Context {
+
+        private com.codahale.metrics.Timer.Context context;
+
+        private ContextImpl(com.codahale.metrics.Timer.Context context) {
+            this.context = context;
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see org.wso2.carbon.metrics.manager.Timer.Context#stop()
+         */
+        @Override
+        public long stop() {
+            return context.stop();
+        }
+
+        /*
+         * (non-Javadoc)
+         * 
+         * @see org.wso2.carbon.metrics.manager.Timer.Context#close()
+         */
+        @Override
+        public void close() {
+            context.close();
+        }
+
+    }
+
+    private static class DummyContextImpl implements Context {
+
+        @Override
+        public long stop() {
+            return 0;
+        }
+
+        @Override
+        public void close() {
+        }
+
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Timer#update(long, java.util.concurrent.TimeUnit)
+     */
+    @Override
+    public void update(long duration, TimeUnit unit) {
+        if (isEnabled()) {
+            timer.update(duration, unit);
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Timer#time(java.util.concurrent.Callable)
+     */
+    @Override
+    public <T> T time(Callable<T> event) throws Exception {
+        if (isEnabled()) {
+            return timer.time(event);
+        }
+        // TODO Should we throw an exception?
+        return null;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Timer#time()
+     */
+    @Override
+    public Context start() {
+        if (isEnabled()) {
+            return new ContextImpl(timer.time());
+        }
+        return new DummyContextImpl();
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.wso2.carbon.metrics.manager.Timer#getCount()
+     */
+    @Override
+    public long getCount() {
+        return timer.getCount();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/internal/MetricsImplComponent.java
+++ b/core/org.wso2.carbon.metrics.impl/src/main/java/org/wso2/carbon/metrics/impl/internal/MetricsImplComponent.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl.internal;
+
+import java.io.File;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.metrics.impl.MetricsConfigException;
+import org.wso2.carbon.metrics.impl.MetricsConfiguration;
+import org.wso2.carbon.metrics.impl.MetricServiceImpl;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.utils.CarbonUtils;
+
+/**
+ * @scr.component name="org.wso2.carbon.metrics.impl.internal.MetricsImplComponent" immediate="true"
+ */
+public class MetricsImplComponent {
+
+    private static final Log log = LogFactory.getLog(MetricsImplComponent.class);
+
+    private static final String SYSTEM_PROPERTY_METRICS_LEVEL = "metrics.level";
+    private static final String LEVEL = "Level";
+
+    @SuppressWarnings("rawtypes")
+    private ServiceRegistration metricsServiceRegistration;
+
+    protected void activate(ComponentContext componentContext) {
+        if (log.isDebugEnabled()) {
+            log.debug("Metrics manager component activated");
+        }
+        MetricsConfiguration configuration = MetricsConfiguration.getInstance();
+        String filePath = CarbonUtils.getCarbonConfigDirPath() + File.separator + "metrics.xml";
+        try {
+            configuration.load(filePath);
+        } catch (MetricsConfigException e) {
+            if (log.isErrorEnabled()) {
+                log.error("Error reading configuration from " + filePath, e);
+            }
+        }
+
+        // Highest priority is for the System Property
+        String configLevel = System.getProperty(SYSTEM_PROPERTY_METRICS_LEVEL);
+        if (configLevel == null || configLevel.trim().isEmpty()) {
+            configLevel = MetricsConfiguration.getInstance().getFirstProperty(LEVEL);
+        }
+
+        MetricService metricService = new MetricServiceImpl(Level.toLevel(configLevel, Level.OFF));
+
+        metricsServiceRegistration = componentContext.getBundleContext().registerService(
+                MetricService.class.getName(), metricService, null);
+
+    }
+
+    protected void deactivate(ComponentContext componentContext) {
+        if (log.isDebugEnabled()) {
+            log.debug("Deactivating Metrics manager component");
+        }
+        metricsServiceRegistration.unregister();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/CounterTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/CounterTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.Random;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Counter;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.MetricManager;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * Test Cases for {@link Counter}
+ */
+public class CounterTest extends TestCase {
+
+    private MetricService metricService;
+
+    private Random randomGenerator = new Random();
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        metricService = new MetricServiceImpl(Level.TRACE);
+        ServiceReferenceHolder.getInstance().setMetricService(metricService);
+    }
+
+    public void testInitialCount() {
+        Counter counter = MetricManager.counter(Level.INFO, MetricManager.name(this.getClass(), "test-counter"));
+        assertEquals("Initial count should be zero", 0, counter.getCount());
+    }
+
+    public void testSameMetric() {
+        String name = MetricManager.name(this.getClass(), "test-same-counter");
+
+        Counter counter = MetricManager.counter(Level.INFO, name);
+        counter.inc();
+        assertEquals("Count should be one", 1, counter.getCount());
+        Counter counter2 = MetricManager.counter(Level.INFO, name);
+        assertEquals("Count should be one", 1, counter2.getCount());
+    }
+
+    public void testIncrementByOne() {
+        Counter counter = MetricManager.counter(Level.INFO, MetricManager.name(this.getClass(), "test-counter-inc1"));
+        counter.inc();
+        assertEquals("Count should be one", 1, counter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        counter.inc();
+        assertEquals("Count should be one", 1, counter.getCount());
+    }
+
+    public void testIncrementByRandomNumber() {
+        Counter counter = MetricManager.counter(Level.INFO,
+                MetricManager.name(this.getClass(), "test-counter-inc-rand"));
+        int n = randomGenerator.nextInt();
+        counter.inc(n);
+        assertEquals("Count should be " + n, n, counter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        counter.inc(n);
+        assertEquals("Count should be " + n, n, counter.getCount());
+    }
+
+    public void testDecrementByOne() {
+        Counter counter = MetricManager.counter(Level.INFO, MetricManager.name(this.getClass(), "test-counter-dec1"));
+        counter.dec();
+        assertEquals("Count should be -1", -1, counter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        counter.dec();
+        assertEquals("Count should be -1", -1, counter.getCount());
+    }
+
+    public void testDecrementByRandomNumber() {
+        Counter counter = MetricManager.counter(Level.INFO,
+                MetricManager.name(this.getClass(), "test-counter-dec-rand"));
+        int n = randomGenerator.nextInt();
+        counter.dec(n);
+        assertEquals("Count should be " + n, 0 - n, counter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        counter.dec(n);
+        assertEquals("Count should be " + n, 0 - n, counter.getCount());
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/GaugeTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/GaugeTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Gauge;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.MetricManager;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * Test Cases for {@link Gauge}
+ */
+public class GaugeTest extends TestCase {
+
+    private MetricService metricService;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        metricService = new MetricServiceImpl(Level.TRACE);
+        ServiceReferenceHolder.getInstance().setMetricService(metricService);
+    }
+
+    public void testSameMetric() {
+        String name = MetricManager.name(this.getClass(), "test-same-guage");
+
+        Gauge<Integer> gauge = new Gauge<Integer>() {
+            @Override
+            public Integer getValue() {
+                return 1;
+            }
+        };
+
+        MetricManager.gauge(Level.INFO, name, gauge);
+
+        // This call also should be successful as we are getting the same gauge
+        MetricManager.gauge(Level.INFO, name, gauge);
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/HistogramTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/HistogramTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.Random;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Histogram;
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.MetricManager;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * Test Cases for {@link Histogram}
+ */
+public class HistogramTest extends TestCase {
+
+    private MetricService metricService;
+
+    private Random randomGenerator = new Random();
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        metricService = new MetricServiceImpl(Level.TRACE);
+        ServiceReferenceHolder.getInstance().setMetricService(metricService);
+    }
+
+    public void testInitialCount() {
+        Histogram histogram = MetricManager.histogram(Level.INFO,
+                MetricManager.name(this.getClass(), "test-initial-count"));
+        assertEquals("Initial count should be zero", 0, histogram.getCount());
+    }
+
+    public void testSameMetric() {
+        String name = MetricManager.name(this.getClass(), "test-same-histogram");
+        Histogram histogram = MetricManager.histogram(Level.INFO, name);
+        histogram.update(randomGenerator.nextInt());
+        assertEquals("Count should be one", 1, histogram.getCount());
+
+        Histogram histogram2 = MetricManager.histogram(Level.INFO, name);
+        assertEquals("Count should be one", 1, histogram2.getCount());
+    }
+
+    public void testUpdateInt() {
+        Histogram histogram = MetricManager.histogram(Level.INFO,
+                MetricManager.name(this.getClass(), "test-histogram-update-int"));
+        histogram.update(randomGenerator.nextInt());
+        assertEquals("Count should be one", 1, histogram.getCount());
+
+        metricService.setLevel(Level.OFF);
+        histogram.update(randomGenerator.nextInt());
+        assertEquals("Count should be one", 1, histogram.getCount());
+    }
+
+    public void testUpdateLong() {
+        Histogram histogram = MetricManager.histogram(Level.INFO,
+                MetricManager.name(this.getClass(), "test-histogram-update-long"));
+
+        histogram.update(randomGenerator.nextLong());
+        assertEquals("Count should be one", 1, histogram.getCount());
+
+        metricService.setLevel(Level.OFF);
+        histogram.update(randomGenerator.nextLong());
+        assertEquals("Count should be one", 1, histogram.getCount());
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/MeterTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/MeterTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.Random;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.Meter;
+import org.wso2.carbon.metrics.manager.MetricManager;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * Test Cases for {@link Meter}
+ */
+public class MeterTest extends TestCase {
+
+    private MetricService metricService;
+
+    private Random randomGenerator = new Random();
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        metricService = new MetricServiceImpl(Level.TRACE);
+        ServiceReferenceHolder.getInstance().setMetricService(metricService);
+    }
+
+    public void testInitialCount() {
+        Meter meter = MetricManager.meter(Level.INFO, MetricManager.name(this.getClass(), "test-initial-count"));
+        assertEquals("Initial count should be zero", 0, meter.getCount());
+        Meter meter2 = MetricManager.meter(Level.INFO, MetricManager.name(this.getClass(), "test-initial-count"));
+        assertEquals("Initial count should be zero", 0, meter2.getCount());
+    }
+
+    public void testSameMetric() {
+        String name = MetricManager.name(this.getClass(), "test-same-meter");
+        Meter meter = MetricManager.meter(Level.INFO, name);
+        meter.mark();
+        assertEquals("Count should be one", 1, meter.getCount());
+
+        Meter meter2 = MetricManager.meter(Level.INFO, name);
+        assertEquals("Count should be one", 1, meter2.getCount());
+    }
+
+    public void testMarkEvent() {
+        Meter meter = MetricManager.meter(Level.INFO, MetricManager.name(this.getClass(), "test-meter-mark"));
+        meter.mark();
+        assertEquals("Count should be one", 1, meter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        meter.mark();
+        assertEquals("Count should be one", 1, meter.getCount());
+    }
+
+    public void testMarkEventByRandomNumber() {
+        Meter meter = MetricManager.meter(Level.INFO, MetricManager.name(this.getClass(), "test-meter-mark-rand"));
+        int n = randomGenerator.nextInt();
+        meter.mark(n);
+        assertEquals("Count should be " + n, n, meter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        meter.mark(n);
+        assertEquals("Count should be " + n, n, meter.getCount());
+    }
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/MetricsConfigurationTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/MetricsConfigurationTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.net.URL;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Level;
+
+/**
+ * Test Cases for {@link MetricsConfiguration}
+ */
+public class MetricsConfigurationTest extends TestCase {
+
+    private static final String LEVEL = "Level";
+    private static final String CSV_REPORTING_LOCATION = "Reporting.CSV.Location";
+
+    protected void setUp() throws Exception {
+        System.setProperty("carbon.home", "/wso2/carbon");
+
+        URL file = getClass().getResource("/metrics.xml");
+        String filePath = file.getPath();
+        MetricsConfiguration configuration = MetricsConfiguration.getInstance();
+        configuration.load(filePath);
+    }
+
+    public void testConfigLoad() {
+        String configLevel = MetricsConfiguration.getInstance().getFirstProperty(LEVEL);
+        assertEquals("Level should be OFF", Level.OFF.name(), configLevel);
+
+        String csvLocation = MetricsConfiguration.getInstance().getFirstProperty(CSV_REPORTING_LOCATION);
+        assertEquals("/wso2/carbon/repository/logs/metrics/", csvLocation);
+    }
+
+    public void testSystemPropertiesReplacements() {
+        System.setProperty("user.home", "/home/test");
+        assertEquals("/home/test/file", MetricsConfiguration.replaceSystemProperties("${user.home}/file"));
+        assertEquals("/home/test/file/wso2/carbon",
+                MetricsConfiguration.replaceSystemProperties("${user.home}/file${carbon.home}"));
+    }
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/MetricsServiceTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/MetricsServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.Meter;
+import org.wso2.carbon.metrics.manager.MetricManager;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * Test Cases for {@link MetricService}
+ */
+public class MetricsServiceTest extends TestCase {
+
+    private static MetricService metricService;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        metricService = new MetricServiceImpl(Level.OFF);
+        ServiceReferenceHolder.getInstance().setMetricService(metricService);
+    }
+
+    public void testMeterInitialCount() {
+        Meter meter = MetricManager.meter(Level.INFO, MetricManager.name(this.getClass(), "test-initial-count"));
+        assertEquals("Initial count should be zero", 0, meter.getCount());
+        assertEquals("Metrics count should be one", 1, metricService.getMetricsCount());
+    }
+
+    public void testMetricServiceLevels() {
+        Meter meter = MetricManager.meter(Level.INFO, MetricManager.name(this.getClass(), "test-levels"));
+        meter.mark();
+        // This is required as we need to check whether level changes are applied to existing metrics
+        assertEquals("Count should be zero", 0, meter.getCount());
+
+        metricService.setLevel(Level.TRACE);
+        meter.mark();
+        assertEquals("Count should be one", 1, meter.getCount());
+
+        metricService.setLevel(Level.DEBUG);
+        meter.mark();
+        assertEquals("Count should be two", 2, meter.getCount());
+
+        metricService.setLevel(Level.INFO);
+        meter.mark();
+        assertEquals("Count should be three", 3, meter.getCount());
+
+        metricService.setLevel(Level.ALL);
+        meter.mark();
+        assertEquals("Count should be four", 4, meter.getCount());
+
+        metricService.setLevel(Level.OFF);
+        meter.mark();
+        // There should be no change
+        assertEquals("Count should be four", 4, meter.getCount());
+    }
+
+    public void testMetricLevels() {
+        Meter meter = MetricManager.meter(Level.OFF, MetricManager.name(this.getClass(), "test1"));
+        meter.mark();
+        assertEquals("Count should be zero", 0, meter.getCount());
+        metricService.setLevel(Level.OFF);
+        meter.mark();
+        assertEquals("Count should be zero", 0, meter.getCount());
+
+        metricService.setLevel(Level.TRACE);
+        meter = MetricManager.meter(Level.TRACE, MetricManager.name(this.getClass(), "test2"));
+        meter.mark();
+        assertEquals("Count should be one", 1, meter.getCount());
+
+        meter = MetricManager.meter(Level.DEBUG, MetricManager.name(this.getClass(), "test3"));
+        meter.mark();
+        assertEquals("Count should be one", 1, meter.getCount());
+
+        metricService.setLevel(Level.DEBUG);
+        meter = MetricManager.meter(Level.TRACE, MetricManager.name(this.getClass(), "test4"));
+        meter.mark();
+        assertEquals("Count should be zero", 0, meter.getCount());
+
+        meter = MetricManager.meter(Level.DEBUG, MetricManager.name(this.getClass(), "test5"));
+        meter.mark(100);
+        assertEquals("Count should be one hundred", 100, meter.getCount());
+
+    }
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/TimerTest.java
+++ b/core/org.wso2.carbon.metrics.impl/src/test/java/org/wso2/carbon/metrics/impl/TimerTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.impl;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.TestCase;
+
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.MetricManager;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.Timer;
+import org.wso2.carbon.metrics.manager.Timer.Context;
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * Test Cases for {@link Timer}
+ */
+public class TimerTest extends TestCase {
+
+    private MetricService metricService;
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        metricService = new MetricServiceImpl(Level.TRACE);
+        ServiceReferenceHolder.getInstance().setMetricService(metricService);
+    }
+
+    public void testInitialCount() {
+        Timer timer = MetricManager.timer(Level.INFO, MetricManager.name(this.getClass(), "test-initial-count"));
+        assertEquals("Initial count should be zero", 0, timer.getCount());
+    }
+    
+    public void testSameMetric() {
+        String name = MetricManager.name(this.getClass(), "test-same-timer");
+        Timer timer = MetricManager.timer(Level.INFO, name);
+        timer.update(1, TimeUnit.SECONDS);
+        assertEquals("Timer count should be one", 1, timer.getCount());
+
+        Timer timer2 = MetricManager.timer(Level.INFO, name);
+        assertEquals("Timer count should be one", 1, timer2.getCount());
+    }
+
+    public void testTime() {
+        Timer timer = MetricManager.timer(Level.INFO, MetricManager.name(this.getClass(), "test-timer-start"));
+        Context context = timer.start();
+        assertTrue("Timer works!", context.stop() > 0);
+        assertEquals("Timer count should be one", 1, timer.getCount());
+
+        metricService.setLevel(Level.OFF);
+        context = timer.start();
+        assertEquals("Timer should not work", 0, context.stop());
+    }
+
+    public void testTimerUpdateCount() {
+        Timer timer = MetricManager.timer(Level.INFO, MetricManager.name(this.getClass(), "test-timer-update"));
+        timer.update(1, TimeUnit.SECONDS);
+        assertEquals("Timer count should be one", 1, timer.getCount());
+
+        metricService.setLevel(Level.OFF);
+        timer.update(1, TimeUnit.SECONDS);
+        assertEquals("Timer count should be one", 1, timer.getCount());
+    }
+
+    public void testTimerCallableInstances() throws Exception {
+        Timer timer = MetricManager.timer(Level.INFO, MetricManager.name(this.getClass(), "test-timer-callable"));
+        Callable<String> callable = new Callable<String>() {
+            @Override
+            public String call() throws Exception {
+                return "test";
+            }
+
+        };
+        String value = timer.time(callable);
+        assertEquals("Value should be 'test'", "test", value);
+
+        metricService.setLevel(Level.OFF);
+        value = timer.time(callable);
+        assertNull("Value should be null", value);
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.impl/src/test/resources/metrics.xml
+++ b/core/org.wso2.carbon.metrics.impl/src/test/resources/metrics.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    ~ Copyright 2014 WSO2 Inc. (http://wso2.org)
+    ~
+    ~ Licensed under the Apache License, Version 2.0 (the "License");
+    ~ you may not use this file except in compliance with the License.
+    ~ You may obtain a copy of the License at
+    ~
+    ~ http://www.apache.org/licenses/LICENSE-2.0
+    ~
+    ~ Unless required by applicable law or agreed to in writing, software
+    ~ distributed under the License is distributed on an "AS IS" BASIS,
+    ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    ~ See the License for the specific language governing permissions and
+    ~ limitations under the License.
+-->
+<!--
+    This is the main configuration file for metrics
+-->
+<Metrics xmlns="http://wso2.org/projects/carbon/metrics.xml">
+
+    <!--
+        Metrics Levels are organized from most specific to least:
+
+        OFF (most specific, no metrics)
+        INFO
+        DEBUG
+        TRACE (least specific, a lot of data)
+        ALL (least specific, all data)
+    -->
+    <Level>OFF</Level>
+
+    <!--
+        Metrics reporting configurations
+    -->
+    <Reporting>
+        <JMX>
+            <Enabled>true</Enabled>
+        </JMX>
+        <CSV>
+            <Enabled>true</Enabled>
+            <Location>${carbon.home}/repository/logs/metrics/</Location>
+            <!-- Polling Period in seconds -->
+            <PollingPeriod>60</PollingPeriod>
+        </CSV>
+    </Reporting>
+</Metrics>

--- a/core/org.wso2.carbon.metrics.manager/pom.xml
+++ b/core/org.wso2.carbon.metrics.manager/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    # Copyright 2014 WSO2 Inc. (http://wso2.org)
+    #
+    # Licensed under the Apache License, Version 2.0 (the "License");
+    # you may not use this file except in compliance with the License.
+    # You may obtain a copy of the License at
+    #
+    # http://www.apache.org/licenses/LICENSE-2.0
+    #
+    # Unless required by applicable law or agreed to in writing, software
+    # distributed under the License is distributed on an "AS IS" BASIS,
+    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    # See the License for the specific language governing permissions and
+    # limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"
+>
+    <parent>
+        <groupId>org.wso2.carbon</groupId>
+        <artifactId>carbon-kernel</artifactId>
+        <version>4.4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.metrics.manager</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Metrics Manager</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.logging</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>
+                            org.wso2.carbon.metrics.manager.*;
+                        </Export-Package>
+                        <DynamicImport-Package>*</DynamicImport-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-scr-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-scr-scrdescriptor</id>
+                        <goals>
+                            <goal>scr</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Counter.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Counter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+/**
+ * An incrementing and decrementing counter metric.
+ */
+public interface Counter extends Metric {
+
+    /**
+     * Increment the counter by one.
+     */
+    void inc();
+
+    /**
+     * Increment the counter by {@code n}.
+     *
+     * @param n the amount by which the counter will be increased
+     */
+    void inc(long n);
+
+    /**
+     * Decrement the counter by one.
+     */
+    void dec();
+
+    /**
+     * Decrement the counter by {@code n}.
+     *
+     * @param n the amount by which the counter will be decreased
+     */
+    void dec(long n);
+
+    /**
+     * Returns the counter's current value.
+     *
+     * @return the counter's current value
+     */
+    long getCount();
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Gauge.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Gauge.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+/**
+ * A metric to read a particular value
+ */
+public interface Gauge<T> extends Metric {
+
+    /**
+     * Returns the metric's current value.
+     *
+     * @return the metric's current value
+     */
+    T getValue();
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Histogram.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Histogram.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+/**
+ * A metric to calculate the distribution of a value.
+ */
+public interface Histogram extends Metric {
+
+    /**
+     * Adds a recorded value.
+     *
+     * @param value the length of the value
+     */
+    void update(int value);
+
+    /**
+     * Adds a recorded value.
+     *
+     * @param value the length of the value
+     */
+    void update(long value);
+
+    /**
+     * Returns the number of values recorded.
+     *
+     * @return the number of values recorded
+     */
+    long getCount();
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Level.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Level.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * <p>
+ * This class defines a set of standard levels to be used in Metrics. This class is similar to
+ * org.apache.logging.log4j.Level in Apache Log4j 2 project.
+ * </p>
+ * <p>
+ * Levels are organized from most specific to least:
+ * </p>
+ * <ul>
+ * <li>{@link #OFF} (most specific, no metrics)</li>
+ * <li>{@link #INFO}</li>
+ * <li>{@link #DEBUG}</li>
+ * <li>{@link #TRACE} (least specific, a lot of data)</li>
+ * <li>{@link #ALL} (least specific, all data)</li>
+ * </ul>
+ */
+public class Level implements Comparable<Level> {
+
+    private final String name;
+
+    private final int intLevel;
+
+    private static final ConcurrentMap<String, Level> levels = new ConcurrentHashMap<String, Level>();
+
+    /**
+     * No events will be used for metrics.
+     */
+    public static final Level OFF;
+
+    /**
+     * A metric for informational purposes.
+     */
+    public static final Level INFO;
+
+    /**
+     * A general debugging metric.
+     */
+    public static final Level DEBUG;
+
+    /**
+     * A fine-grained metric
+     */
+    public static final Level TRACE;
+
+    /**
+     * All metrics should be enabled.
+     */
+    public static final Level ALL;
+
+    static {
+        OFF = new Level("OFF", 0);
+        INFO = new Level("INFO", 400);
+        DEBUG = new Level("DEBUG", 500);
+        TRACE = new Level("TRACE", 600);
+        ALL = new Level("ALL", Integer.MAX_VALUE);
+    }
+
+    private Level(final String name, final int intLevel) {
+        if (name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("Illegal null Level constant");
+        }
+        if (intLevel < 0) {
+            throw new IllegalArgumentException("Illegal Level int less than zero.");
+        }
+        this.name = name;
+        this.intLevel = intLevel;
+        if (levels.putIfAbsent(name, this) != null) {
+            throw new IllegalStateException("Level " + name + " has already been defined.");
+        }
+    }
+
+    /**
+     * Gets the integral value of this Level.
+     *
+     * @return the value of this Level.
+     */
+    public int intLevel() {
+        return this.intLevel;
+    }
+
+    @Override
+    public int compareTo(final Level other) {
+        return intLevel < other.intLevel ? -1 : (intLevel > other.intLevel ? 1 : 0);
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        return other instanceof Level && other == this;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.name.hashCode();
+    }
+
+    /**
+     * Gets the symbolic name of this Level. Equivalent to calling {@link #toString()}.
+     *
+     * @return the name of this Level.
+     */
+    public String name() {
+        return this.name;
+    }
+
+    @Override
+    public String toString() {
+        return this.name;
+    }
+
+    /**
+     * Return the Level associated with the name or null if the Level cannot be found.
+     * 
+     * @param name The name of the Level.
+     * @return The Level or null.
+     */
+    public static Level getLevel(final String name) {
+        return levels.get(name);
+    }
+
+    /**
+     * Converts the string passed as argument to a level. If the conversion fails, then this method returns
+     * {@link #DEBUG}.
+     *
+     * @param sArg The name of the desired Level.
+     * @return The Level associated with the String.
+     */
+    public static Level toLevel(final String sArg) {
+        return toLevel(sArg, Level.DEBUG);
+    }
+
+    /**
+     * Converts the string passed as argument to a level. If the conversion fails, then this method returns the value of
+     * <code>defaultLevel</code>.
+     *
+     * @param name The name of the desired Level.
+     * @param defaultLevel The Level to use if the String is invalid.
+     * @return The Level associated with the String.
+     */
+    public static Level toLevel(final String name, final Level defaultLevel) {
+        if (name == null) {
+            return defaultLevel;
+        }
+        final Level level = levels.get(name.toUpperCase(Locale.ENGLISH));
+        return level == null ? defaultLevel : level;
+    }
+
+    /**
+     * Return the Level associated with the name.
+     * 
+     * @param name The name of the Level to return.
+     * @return The Level.
+     * @throws java.lang.NullPointerException if the Level name is {@code null}.
+     * @throws java.lang.IllegalArgumentException if the Level name is not registered.
+     */
+    public static Level valueOf(final String name) {
+        if (name == null) {
+            throw new NullPointerException("No level name given.");
+        }
+        final String levelName = name.toUpperCase();
+        if (levels.containsKey(levelName)) {
+            return levels.get(levelName);
+        }
+        throw new IllegalArgumentException("Unknown level constant [" + levelName + "].");
+    }
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Meter.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Meter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+/**
+ * A metric to measure the the rate of events over time
+ */
+public interface Meter extends Metric {
+
+    /**
+     * Mark the occurrence of an event.
+     */
+    void mark();
+
+    /**
+     * Mark the occurrence of a given number of events.
+     *
+     * @param n the number of events
+     */
+    void mark(long n);
+
+    /**
+     * Returns the number of events which have been marked.
+     *
+     * @return the number of events which have been marked
+     */
+    long getCount();
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Metric.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Metric.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+/**
+ * A tag interface to indicate a metric class
+ */
+public interface Metric {
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/MetricManager.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/MetricManager.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.wso2.carbon.metrics.manager.internal.ServiceReferenceHolder;
+
+/**
+ * MetricManager is a static utility class providing various metrics.
+ */
+public final class MetricManager {
+
+    private static final ConcurrentMap<String, MetricWrapper<? extends Metric>> metrics = new ConcurrentHashMap<String, MetricWrapper<? extends Metric>>();
+
+    private MetricManager() {
+    }
+
+    /**
+     * MetricWrapper class is used for the metrics map. This class keeps the associated {@link Level} with metric
+     */
+    private static class MetricWrapper<T extends Metric> {
+
+        private final Level level;
+        private final T metric;
+
+        private MetricWrapper(Level level, T metric) {
+            super();
+            this.level = level;
+            this.metric = metric;
+        }
+    }
+
+    /**
+     * Concatenates elements to form a dotted name
+     *
+     * @param name the first element of the name
+     * @param names the remaining elements of the name
+     * @return {@code name} and {@code names} concatenated by periods
+     */
+    public static String name(String name, String... names) {
+        final StringBuilder builder = new StringBuilder();
+        append(builder, name);
+        if (names != null) {
+            for (String s : names) {
+                append(builder, s);
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Concatenates a class name and elements to form a dotted name
+     *
+     * @param klass the first element of the name
+     * @param names the remaining elements of the name
+     * @return {@code klass} and {@code names} concatenated by periods
+     */
+    public static String name(Class<?> klass, String... names) {
+        return name(klass.getName(), names);
+    }
+
+    private static void append(StringBuilder builder, String part) {
+        if (part != null && !part.isEmpty()) {
+            if (builder.length() > 0) {
+                builder.append('.');
+            }
+            builder.append(part);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends Metric> T getOrCreateMetric(Level level, String name, MetricBuilder<T> metricBuilder) {
+        MetricWrapper<? extends Metric> metricWrapper = metrics.get(name);
+        if (metricWrapper != null) {
+            Metric metric = metricWrapper.metric;
+            if (metricBuilder.isInstance(metric)) {
+                if (level.equals(metricWrapper.level)) {
+                    return (T) metric;
+                } else {
+                    throw new IllegalArgumentException(name + " is already used with a different level");
+                }
+            } else {
+                throw new IllegalArgumentException(name + " is already used for a different type of metric");
+            }
+        } else {
+            T newMetric = metricBuilder.createMetric(level, name);
+            metricWrapper = new MetricWrapper<T>(level, newMetric);
+            metrics.put(name, metricWrapper);
+            return newMetric;
+        }
+    }
+
+    /**
+     * An interface for creating a new metric from MetricService
+     */
+    private static interface MetricBuilder<T extends Metric> {
+        T createMetric(Level level, String name);
+
+        boolean isInstance(Metric metric);
+    }
+
+    private static final MetricBuilder<Meter> METER_BUILDER = new MetricBuilder<Meter>() {
+        @Override
+        public Meter createMetric(Level level, String name) {
+            MetricService metricService = ServiceReferenceHolder.getInstance().getMetricService();
+            return metricService.createMeter(level, name);
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return Meter.class.isInstance(metric);
+        }
+    };
+
+    private static final MetricBuilder<Counter> COUNTER_BUILDER = new MetricBuilder<Counter>() {
+        @Override
+        public Counter createMetric(Level level, String name) {
+            MetricService metricService = ServiceReferenceHolder.getInstance().getMetricService();
+            return metricService.createCounter(level, name);
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return Counter.class.isInstance(metric);
+        }
+    };
+
+    private static final MetricBuilder<Timer> TIMER_BUILDER = new MetricBuilder<Timer>() {
+        @Override
+        public Timer createMetric(Level level, String name) {
+            MetricService metricService = ServiceReferenceHolder.getInstance().getMetricService();
+            return metricService.createTimer(level, name);
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return Timer.class.isInstance(metric);
+        }
+    };
+
+    private static final MetricBuilder<Histogram> HISTOGRAM_BUILDER = new MetricBuilder<Histogram>() {
+        @Override
+        public Histogram createMetric(Level level, String name) {
+            MetricService metricService = ServiceReferenceHolder.getInstance().getMetricService();
+            return metricService.createHistogram(level, name);
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return Histogram.class.isInstance(metric);
+        }
+    };
+
+    private static class GaugeBuilder<T> implements MetricBuilder<Gauge<T>> {
+
+        private final Gauge<T> gauge;
+
+        public GaugeBuilder(Gauge<T> gauge) {
+            super();
+            this.gauge = gauge;
+        }
+
+        @Override
+        public Gauge<T> createMetric(Level level, String name) {
+            MetricService metricService = ServiceReferenceHolder.getInstance().getMetricService();
+            metricService.createGauge(level, name, gauge);
+            return gauge;
+        }
+
+        @Override
+        public boolean isInstance(Metric metric) {
+            return Gauge.class.isInstance(metric);
+        }
+    };
+
+    private static class CachedGaugeBuilder<T> extends GaugeBuilder<T> implements MetricBuilder<Gauge<T>> {
+
+        private final Gauge<T> gauge;
+        private final long timeout;
+        private final TimeUnit timeoutUnit;
+
+        public CachedGaugeBuilder(Gauge<T> gauge, long timeout, TimeUnit timeoutUnit) {
+            super(gauge);
+            this.gauge = gauge;
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+        }
+
+        @Override
+        public Gauge<T> createMetric(Level level, String name) {
+            MetricService metricService = ServiceReferenceHolder.getInstance().getMetricService();
+            metricService.createCachedGauge(level, name, timeout, timeoutUnit, gauge);
+            return gauge;
+        }
+
+    };
+
+    /**
+     * Return a {@link Meter} instance registered under given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Meter} instance
+     */
+    public static Meter meter(Level level, String name) {
+        return getOrCreateMetric(level, name, METER_BUILDER);
+    }
+
+    /**
+     * Return a {@link Counter} instance registered under given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Counter} instance
+     */
+    public static Counter counter(Level level, String name) {
+        return getOrCreateMetric(level, name, COUNTER_BUILDER);
+    }
+
+    /**
+     * Return a {@link Timer} instance registered under given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Timer} instance
+     */
+    public static Timer timer(Level level, String name) {
+        return getOrCreateMetric(level, name, TIMER_BUILDER);
+    }
+
+    /**
+     * Return a {@link Histogram} instance registered under given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Histogram} instance
+     */
+    public static Histogram histogram(Level level, String name) {
+        return getOrCreateMetric(level, name, HISTOGRAM_BUILDER);
+    }
+
+    /**
+     * Register a {@link Gauge} instance under given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @param gauge An implementation of {@link Gauge}
+     */
+    public static <T> void gauge(Level level, String name, Gauge<T> gauge) {
+        getOrCreateMetric(level, name, new GaugeBuilder<T>(gauge));
+    }
+
+    /**
+     * Register a {@link Gauge} instance under given name with a configurable cache timeout
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metrics
+     * @param timeout The timeout value
+     * @param timeoutUnit The {@link TimeUnit} for the {@link timeout}
+     * @param gauge An implementation of {@link Gauge}
+     */
+    public static <T> void cachedGauge(Level level, String name, long timeout, TimeUnit timeoutUnit, Gauge<T> gauge) {
+        getOrCreateMetric(level, name, new CachedGaugeBuilder<T>(gauge, timeout, timeoutUnit));
+    }
+
+    /**
+     * Register a {@link Gauge} instance under given name with a configurable cache timeout in seconds
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metrics
+     * @param timeout The timeout value in seconds
+     * @param gauge An implementation of {@link Gauge}
+     */
+    public static <T> void cachedGauge(Level level, String name, long timeout, Gauge<T> gauge) {
+        getOrCreateMetric(level, name, new CachedGaugeBuilder<T>(gauge, timeout, TimeUnit.SECONDS));
+    }
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/MetricService.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/MetricService.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Main interface for the service creating various metrics
+ */
+public interface MetricService {
+
+    /**
+     * @return The current {@link Level}
+     */
+    Level getLevel();
+
+    /**
+     * Set a new level to the Metrics Service
+     * 
+     * @param level New {@link Level}
+     */
+    void setLevel(Level level);
+
+    /**
+     * Return the number of metrics used
+     * 
+     * @return The metrics count
+     */
+    int getMetricsCount();
+
+    /**
+     * Create a {@link Meter} instance for the given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Meter} instance
+     */
+    Meter createMeter(Level level, String name);
+
+    /**
+     * Create a {@link Counter} instance for the given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Counter} instance
+     */
+    Counter createCounter(Level level, String name);
+
+    /**
+     * Create a {@link Timer} instance for the given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Timer} instance
+     */
+    Timer createTimer(Level level, String name);
+
+    /**
+     * Create a {@link Histogram} instance for the given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @return a {@link Histogram} instance
+     */
+    Histogram createHistogram(Level level, String name);
+
+    /**
+     * Register a {@link Gauge} for the given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @param gauge An implementation of {@link Gauge}
+     */
+    <T> void createGauge(Level level, String name, Gauge<T> gauge);
+
+    /**
+     * Register a cached {@link Gauge} for the given name
+     * 
+     * @param level The {@link Level} used for metric
+     * @param name The name of the metric
+     * @param timeout the timeout
+     * @param timeoutUnit the unit of {@code timeout}
+     * @param gauge An implementation of {@link Gauge}
+     */
+    <T> void createCachedGauge(Level level, String name, long timeout, TimeUnit timeoutUnit, Gauge<T> gauge);
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Timer.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/Timer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager;
+
+import java.io.Closeable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A metric for measuring the duration of a particular piece of code
+ */
+public interface Timer extends Metric {
+
+    /**
+     * Adds a recorded duration.
+     *
+     * @param duration the length of the duration
+     * @param unit the scale unit of {@code duration}
+     */
+    void update(long duration, TimeUnit unit);
+
+    /**
+     * Times and records the duration of event.
+     *
+     * @param event a {@link Callable} whose {@link Callable#call()} method implements a process whose duration should
+     *            be timed
+     * @param <T> the type of the value returned by {@code event}
+     * @return the value returned by {@code event}
+     * @throws Exception if {@code event} throws an {@link Exception}
+     */
+    <T> T time(Callable<T> event) throws Exception;
+
+    /**
+     * Returns a new {@link Context}
+     *
+     * @return a new {@link Context}
+     * @see Context
+     */
+    Context start();
+
+    long getCount();
+
+    public static interface Context extends Closeable {
+
+        /**
+         * Updates the timer with the difference between current and start time. Call to this method will not reset the
+         * start time. Multiple calls result in multiple updates.
+         * 
+         * @return the elapsed time in nanoseconds
+         */
+        long stop();
+
+        void close();
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/internal/MetricManagerComponent.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/internal/MetricManagerComponent.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager.internal;
+
+import java.lang.management.ManagementFactory;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.wso2.carbon.metrics.manager.MetricService;
+import org.wso2.carbon.metrics.manager.jmx.MetricManagerMXBean;
+import org.wso2.carbon.metrics.manager.jmx.MetricManagerMXBeanImpl;
+
+/**
+ * @scr.component name="org.wso2.carbon.metrics.manager.internal.MetricManagerComponent" immediate="true"
+ * @scr.reference name="metric.service" interface="org.wso2.carbon.metrics.manager.MetricService" cardinality="1..1"
+ *                policy="dynamic" bind="setMetricService" unbind="unsetMetricService"
+ */
+public class MetricManagerComponent {
+
+    private static final Log log = LogFactory.getLog(MetricManagerComponent.class);
+
+    private static final String MBEAN_NAME = "org.wso2.carbon:type=MetricManager";
+
+    private ServiceReferenceHolder serviceReferenceHolder = ServiceReferenceHolder.getInstance();
+
+    protected void activate(ComponentContext componentContext) {
+        if (log.isDebugEnabled()) {
+            log.debug("Metrics manager component activated");
+        }
+
+        registerMXBean();
+    }
+
+    private void registerMXBean() {
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        try {
+            ObjectName name = new ObjectName(MBEAN_NAME);
+            if (mBeanServer.isRegistered(name)) {
+                mBeanServer.unregisterMBean(name);
+            }
+            MetricManagerMXBean mxBean = new MetricManagerMXBeanImpl(serviceReferenceHolder.getMetricService());
+            mBeanServer.registerMBean(mxBean, name);
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("MetricManagerMXBean registered under name: %s", name));
+            }
+        } catch (JMException e) {
+            if (log.isErrorEnabled()) {
+                log.error(String.format("MetricManagerMXBean registration failed. Name: %s", MBEAN_NAME), e);
+            }
+        }
+    }
+
+    protected void deactivate(ComponentContext componentContext) {
+        if (log.isDebugEnabled()) {
+            log.debug("Deactivating Metrics manager component");
+        }
+
+        unregisterMXBean();
+    }
+
+    private void unregisterMXBean() {
+        MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        try {
+            ObjectName name = new ObjectName(MBEAN_NAME);
+            if (mBeanServer.isRegistered(name)) {
+                mBeanServer.unregisterMBean(name);
+            }
+            if (log.isDebugEnabled()) {
+                log.debug(String.format("MetricManagerMXBean with name '%s' was unregistered.", name));
+            }
+        } catch (JMException e) {
+            if (log.isErrorEnabled()) {
+                log.error(String.format("MetricManagerMXBean with name '%s' was failed to unregister", MBEAN_NAME), e);
+            }
+        }
+    }
+
+    protected void setMetricService(MetricService metricService) {
+        serviceReferenceHolder.setMetricService(metricService);
+    }
+
+    protected void unsetMetricService(MetricService metricService) {
+        serviceReferenceHolder.setMetricService(null);
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/internal/ServiceReferenceHolder.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/internal/ServiceReferenceHolder.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager.internal;
+
+import org.wso2.carbon.metrics.manager.MetricService;
+
+/**
+ * Holding references to the OSGi services
+ */
+public class ServiceReferenceHolder {
+
+    private static final ServiceReferenceHolder INSTANCE = new ServiceReferenceHolder();
+
+    private MetricService metricService;
+
+    public static ServiceReferenceHolder getInstance() {
+        return INSTANCE;
+    }
+
+    private ServiceReferenceHolder() {
+    }
+
+    public void setMetricService(MetricService metricService) {
+        this.metricService = metricService;
+    }
+
+    public MetricService getMetricService() {
+        return metricService;
+    }
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/jmx/MetricManagerMXBean.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/jmx/MetricManagerMXBean.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager.jmx;
+
+/**
+ * Interface for JMX Managed Metric Manager Bean 
+ */
+public interface MetricManagerMXBean {
+    
+    /**
+     * @return The number of metrics used
+     */
+    int getMetricsCount();
+
+    /**
+     * @return Get the current configured level
+     */
+    String getLevel();
+
+    /**
+     * Set level for Metric Service
+     * 
+     * @param level
+     */
+    void setLevel(String level);
+
+}

--- a/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/jmx/MetricManagerMXBeanImpl.java
+++ b/core/org.wso2.carbon.metrics.manager/src/main/java/org/wso2/carbon/metrics/manager/jmx/MetricManagerMXBeanImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014 WSO2 Inc. (http://wso2.org)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.metrics.manager.jmx;
+
+import org.wso2.carbon.metrics.manager.Level;
+import org.wso2.carbon.metrics.manager.MetricService;
+
+/**
+ * Implementation for Metric Manager JMX Bean
+ */
+public class MetricManagerMXBeanImpl implements MetricManagerMXBean {
+
+    private final MetricService metricService;
+
+    public MetricManagerMXBeanImpl(MetricService metricService) {
+        super();
+        this.metricService = metricService;
+    }
+
+    @Override
+    public int getMetricsCount() {
+        return metricService.getMetricsCount();
+    }
+
+    @Override
+    public String getLevel() {
+        return metricService.getLevel().name();
+    }
+
+    @Override
+    public void setLevel(String level) {
+        metricService.setLevel(Level.valueOf(level));
+    }
+
+}

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -162,5 +162,7 @@
         <module>org.wso2.carbon.ndatasource.core</module>
         <module>org.wso2.carbon.ndatasource.rdbms</module>
         <module>org.wso2.carbon.framework.exporter</module>
+        <module>org.wso2.carbon.metrics.manager</module>
+        <module>org.wso2.carbon.metrics.impl</module>
     </modules>
 </project>


### PR DESCRIPTION
There are two components. The org.wso2.carbon.metrics.manager component has the public API for WSO2 Metrics and it is exposed via org.wso2.carbon.metrics.manager.MetricManager class. The org.wso2.carbon.metrics.impl component has the implementation, which uses Metrics library (http://dropwizard.github.io/metrics/).