### PR TITLE
Fix for REGISTRY-2159 - GREG life cycle executor does not run with mounted registry.

### DIFF
--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/RegistryConstants.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/RegistryConstants.java
@@ -1151,4 +1151,9 @@ public final class RegistryConstants {
      * Defines the media type used for symlink and remote link resources.
      * */
     public static final String LINK_MEDIA_TYPE = "application/vnd.wso2-link";
+
+    /**
+     * Media type of the governance archive (.zip or .gar file)
+     */
+    public static final String GOVERNANCE_ARCHIVE = "application/vnd.wso2.governance-archive";
 }

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/builtin/MountHandler.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/builtin/MountHandler.java
@@ -280,6 +280,9 @@ public class MountHandler extends Handler {
             if( RegistryConstants.XSD_MEDIA_TYPE.equals(resource.getMediaType())
                 || RegistryConstants.WSDL_MEDIA_TYPE.equals(resource.getMediaType() )) {
                 resource.addProperty(RegistryConstants.REMOTE_MOUNT_OPERATION, "true");
+            //This is to fix the zip or gar file upload on mount.
+            } else if (RegistryConstants.GOVERNANCE_ARCHIVE.equals(resource.getMediaType())) {
+                return;
             }
             // sets the actual path of the resource
 

--- a/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/builtin/MountHandler.java
+++ b/core/org.wso2.carbon.registry.core/src/main/java/org/wso2/carbon/registry/core/jdbc/handlers/builtin/MountHandler.java
@@ -1163,7 +1163,7 @@ public class MountHandler extends Handler {
             try {
                 boolean connectionExists = false;
                 List<String> conList = getQueriedConnectionList();
-                if (conList == null) {
+                if (conList == null  || !paramMap.containsKey("remote")) {
                     conList = new LinkedList<String>();
                 }
                 for (String con: conList) {


### PR DESCRIPTION
Fix for REGISTRY-2159 - GREG life cycle executor does not run with mounted registry.