### PR TITLE
Identity 3140

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -52,9 +52,6 @@ public class ActiveDirectoryUserStoreConstants {
         setMandatoryProperty(UserStoreConfigConstants.userEntryObjectClass,
                 "User Entry Object Class", "user", UserStoreConfigConstants
                         .userEntryObjectClassDescription, false);
-        setMandatoryProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
-                UserStoreConfigConstants.userDNPatternDescription, false);
-
         setProperty(UserStoreConfigConstants.groupEntryObjectClass, "Group Entry Object Class", "group", UserStoreConfigConstants.groupEntryObjectClassDescription);
 
         setProperty(UserStoreConfigConstants.maxUserNameListLength, "Maximum User List Length", "100", UserStoreConfigConstants.maxUserNameListLengthDescription);
@@ -84,6 +81,7 @@ public class ActiveDirectoryUserStoreConstants {
         setProperty(UserStoreConfigConstants.groupNameSearchFilter, "Group Search Filter", "(&amp;(objectClass=group)(cn=?))", UserStoreConfigConstants.groupNameSearchFilterDescription);
         setProperty(UserStoreConfigConstants.CASE_SENSITIVE_USERNAME, "Case Sensitive Username", "true",
                 UserStoreConfigConstants.CASE_SENSITIVE_USERNAME_DESCRIPTION);
+        setProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "", UserStoreConfigConstants.userDNPatternDescription);
 
 
 //      AD Specific Properties

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ActiveDirectoryUserStoreConstants.java
@@ -52,6 +52,9 @@ public class ActiveDirectoryUserStoreConstants {
         setMandatoryProperty(UserStoreConfigConstants.userEntryObjectClass,
                 "User Entry Object Class", "user", UserStoreConfigConstants
                         .userEntryObjectClassDescription, false);
+        setMandatoryProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
+                UserStoreConfigConstants.userDNPatternDescription, false);
+
         setProperty(UserStoreConfigConstants.groupEntryObjectClass, "Group Entry Object Class", "group", UserStoreConfigConstants.groupEntryObjectClassDescription);
 
         setProperty(UserStoreConfigConstants.maxUserNameListLength, "Maximum User List Length", "100", UserStoreConfigConstants.maxUserNameListLengthDescription);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -50,6 +50,8 @@ public class ReadOnlyLDAPUserStoreConstants {
                         .usernameSearchFilterDescription, false);
         setMandatoryProperty("ReadOnly", "Read-only", "true", "Indicates whether the user store " +
                 "is in read only mode or not", false);
+        setMandatoryProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
+                UserStoreConfigConstants.userDNPatternDescription, false);
 
         setProperty(UserStoreConfigConstants.maxUserNameListLength, "Maximum User List Length", "100", UserStoreConfigConstants.maxUserNameListLengthDescription);
         setProperty(UserStoreConfigConstants.maxRoleNameListLength, "Maximum Role List Length", "100", UserStoreConfigConstants.maxRoleNameListLengthDescription);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreConstants.java
@@ -50,8 +50,6 @@ public class ReadOnlyLDAPUserStoreConstants {
                         .usernameSearchFilterDescription, false);
         setMandatoryProperty("ReadOnly", "Read-only", "true", "Indicates whether the user store " +
                 "is in read only mode or not", false);
-        setMandatoryProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
-                UserStoreConfigConstants.userDNPatternDescription, false);
 
         setProperty(UserStoreConfigConstants.maxUserNameListLength, "Maximum User List Length", "100", UserStoreConfigConstants.maxUserNameListLengthDescription);
         setProperty(UserStoreConfigConstants.maxRoleNameListLength, "Maximum Role List Length", "100", UserStoreConfigConstants.maxRoleNameListLengthDescription);
@@ -96,6 +94,7 @@ public class ReadOnlyLDAPUserStoreConstants {
         setProperty("UniqueID", "", "", "");
         setProperty(UserStoreConfigConstants.CASE_SENSITIVE_USERNAME, "Case Sensitive Username", "true",
                 UserStoreConfigConstants.CASE_SENSITIVE_USERNAME_DESCRIPTION);
+        setProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "", UserStoreConfigConstants.userDNPatternDescription);
 
     }
 

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -54,8 +54,6 @@ public class ReadWriteLDAPUserStoreConstants {
         setMandatoryProperty(UserStoreConfigConstants.groupEntryObjectClass,
                 "Group Entry Object Class", "groupOfNames", UserStoreConfigConstants
                         .groupEntryObjectClassDescription, false);
-        setMandatoryProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
-                UserStoreConfigConstants.userDNPatternDescription, false);
 
         setProperty(UserStoreConfigConstants.maxUserNameListLength, "Maximum User List Length", "100", UserStoreConfigConstants.maxUserNameListLengthDescription);
         setProperty(UserStoreConfigConstants.maxRoleNameListLength, "Maximum Role List Length", "100", UserStoreConfigConstants.maxRoleNameListLengthDescription);
@@ -85,6 +83,7 @@ public class ReadWriteLDAPUserStoreConstants {
 
 //      LDAP Specific Properties
         setProperty(UserStoreConfigConstants.passwordHashMethod, "Password Hashing Algorithm", "SHA", UserStoreConfigConstants.passwordHashMethodDescription);
+        setProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "", UserStoreConfigConstants.userDNPatternDescription);
         setProperty(UserStoreConfigConstants.passwordJavaScriptRegEx, "Password RegEx (Javascript)", "^[\\S]{5,30}$", UserStoreConfigConstants.passwordJavaScriptRegExDescription);
         setProperty(UserStoreConfigConstants.usernameJavaScriptRegEx, "Username RegEx (Javascript)", "^[\\S]{3,30}$", UserStoreConfigConstants.usernameJavaRegExDescription);
         setProperty(UserStoreConfigConstants.usernameJavaRegEx, "Username RegEx (Java)", "[a-zA-Z0-9._-|//]{3,30}$", UserStoreConfigConstants.usernameJavaRegExDescription);

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreConstants.java
@@ -54,6 +54,8 @@ public class ReadWriteLDAPUserStoreConstants {
         setMandatoryProperty(UserStoreConfigConstants.groupEntryObjectClass,
                 "Group Entry Object Class", "groupOfNames", UserStoreConfigConstants
                         .groupEntryObjectClassDescription, false);
+        setMandatoryProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "",
+                UserStoreConfigConstants.userDNPatternDescription, false);
 
         setProperty(UserStoreConfigConstants.maxUserNameListLength, "Maximum User List Length", "100", UserStoreConfigConstants.maxUserNameListLengthDescription);
         setProperty(UserStoreConfigConstants.maxRoleNameListLength, "Maximum Role List Length", "100", UserStoreConfigConstants.maxRoleNameListLengthDescription);
@@ -83,7 +85,6 @@ public class ReadWriteLDAPUserStoreConstants {
 
 //      LDAP Specific Properties
         setProperty(UserStoreConfigConstants.passwordHashMethod, "Password Hashing Algorithm", "SHA", UserStoreConfigConstants.passwordHashMethodDescription);
-        setProperty(UserStoreConfigConstants.userDNPattern, "User DN Pattern", "uid={0},ou=Users,dc=wso2,dc=org", UserStoreConfigConstants.userDNPatternDescription);
         setProperty(UserStoreConfigConstants.passwordJavaScriptRegEx, "Password RegEx (Javascript)", "^[\\S]{5,30}$", UserStoreConfigConstants.passwordJavaScriptRegExDescription);
         setProperty(UserStoreConfigConstants.usernameJavaScriptRegEx, "Username RegEx (Javascript)", "^[\\S]{3,30}$", UserStoreConfigConstants.usernameJavaRegExDescription);
         setProperty(UserStoreConfigConstants.usernameJavaRegEx, "Username RegEx (Java)", "[a-zA-Z0-9._-|//]{3,30}$", UserStoreConfigConstants.usernameJavaRegExDescription);


### PR DESCRIPTION
No need to make UserDN patterns mandatory, but if optional, should correctly set the proper UserDN pattern or leave it empty. 