### PR TITLE
Fix for IDENTITY-3438

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/PermissionTree.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/authorization/PermissionTree.java
@@ -982,7 +982,6 @@ public class PermissionTree {
                 String roleName = rs.getString(1);
                 String domain = rs.getString(5);
                 String roleWithDomain = UserCoreUtil.addDomainToName(roleName, domain);
-                roleWithDomain = roleWithDomain.toLowerCase();
 
                 if (allow == UserCoreConstants.ALLOW) {
                     tree.authorizeRoleInTree(roleWithDomain, rs.getString(2), rs.getString(4), false);


### PR DESCRIPTION
removing mismatch between entry and search in permissiontree