### PR TITLE
fix for CARBON-15346

### DIFF
--- a/core/org.wso2.carbon.application.deployer/src/main/java/org/wso2/carbon/application/deployer/handler/RegistryResourceDeployer.java
+++ b/core/org.wso2.carbon.application.deployer/src/main/java/org/wso2/carbon/application/deployer/handler/RegistryResourceDeployer.java
@@ -30,6 +30,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.deployment.DeploymentException;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ public class RegistryResourceDeployer implements AppDeploymentHandler {
      * @param carbonApp - store info in this object after deploying
      * @param axisConfig - AxisConfiguration of the current tenant
      */
-    public void deployArtifacts(CarbonApplication carbonApp, AxisConfiguration axisConfig) {
+    public void deployArtifacts(CarbonApplication carbonApp, AxisConfiguration axisConfig)  throws DeploymentException {
         ApplicationConfiguration appConfig = carbonApp.getAppConfig();
         List<Artifact.Dependency> deps = appConfig.getApplicationArtifact().getDependencies();
 
@@ -102,7 +103,7 @@ public class RegistryResourceDeployer implements AppDeploymentHandler {
      * @param parentAppName - name of the parent cApp
      */
     private void deployRegistryArtifacts(CarbonAppPersistenceManager capm,
-                                         List<Artifact> artifacts, String parentAppName) {
+                                         List<Artifact> artifacts, String parentAppName) throws DeploymentException{
         for (Artifact artifact : artifacts) {
             if (REGISTRY_RESOURCE_TYPE.equals(artifact.getType())) {
                 try {
@@ -113,6 +114,7 @@ public class RegistryResourceDeployer implements AppDeploymentHandler {
                     artifact.setRegConfig(regConfig);
                 } catch (Exception e) {
                     log.error("Error while deploying registry artifact " + artifact.getName(), e);
+                    throw new DeploymentException(e.getMessage());
                 }
             }
 

--- a/core/org.wso2.carbon.application.deployer/src/main/java/org/wso2/carbon/application/deployer/persistence/CarbonAppPersistenceManager.java
+++ b/core/org.wso2.carbon.application.deployer/src/main/java/org/wso2/carbon/application/deployer/persistence/CarbonAppPersistenceManager.java
@@ -24,6 +24,7 @@ import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.axiom.om.xpath.AXIOMXPath;
 import org.apache.axis2.engine.AxisConfiguration;
+import org.apache.axis2.deployment.DeploymentException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.CarbonConstants;
@@ -290,6 +291,9 @@ public class CarbonAppPersistenceManager {
                     pathMappingResource.setContent(element.toString());
                     configRegistry.put(AppDeployerConstants.REG_PATH_MAPPING +
                             regConfig.getAppName(), pathMappingResource);
+                    } else if (actualResourcePath == null) {
+                        String msg = "Error while deploying registry resource";
+                        throw new DeploymentException(msg);
                 }
             }
         }
@@ -474,7 +478,9 @@ public class CarbonAppPersistenceManager {
                         new StAXOMBuilder(xmlStream).getDocumentElement());
             }
         }
-        regConfig.setAppName(appName);
+        if (regConfig != null){
+            regConfig.setAppName(appName);
+        }
         return regConfig;
     }
     


### PR DESCRIPTION
Registry resource deployer does not undeploy car file when there are faulty artifacts in the car file. Car file will be shown as deployed and artifacts will be partially deployed.