### PR TITLE
Fixing LDAP Injection at Search Filters

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadOnlyLDAPUserStoreManager.java
@@ -2579,7 +2579,7 @@ public class ReadOnlyLDAPUserStoreManager extends AbstractUserStoreManager {
 
                     searchFilter =
                             "(&" + searchFilter + "(" + membershipProperty + "=" + membershipValue +
-                                    ") (" + roleNameProperty + "=" + roleName + "))";
+                                    ") (" + roleNameProperty + "=" + escapeSpecialCharactersForFilter(roleName) + "))";
 
                     // handle multiple search bases 
                     String[] searchBaseArray = searchBases.split("#");

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/ldap/ReadWriteLDAPUserStoreManager.java
@@ -499,7 +499,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                     if (role.indexOf("/") > -1) {
                         role = (role.split("/"))[1];
                     }
-                    String grpSearchFilter = searchFilter.replace("?", role);
+                    String grpSearchFilter = searchFilter.replace("?", escapeSpecialCharactersForFilter(role));
                     groupResults =
                             searchInGroupBase(grpSearchFilter, returningGroupAttributes,
                                     SearchControls.SUBTREE_SCOPE, mainDirContext,
@@ -1231,7 +1231,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                     LDAPRoleContext context = (LDAPRoleContext) createRoleContext(deletedRole);
                     deletedRole = context.getRoleName();
                     String searchFilter = context.getSearchFilter();
-                    roleSearchFilter = searchFilter.replace("?", deletedRole);
+                    roleSearchFilter = searchFilter.replace("?", escapeSpecialCharactersForFilter(deletedRole));
                     String[] returningAttributes = new String[]{membershipAttribute};
                     String searchBase = context.getSearchBase();
                     NamingEnumeration<SearchResult> groupResults =
@@ -1263,7 +1263,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                     String searchFilter = context.getSearchFilter();
 
                     if (isExistingRole(deletedRole)) {
-                        roleSearchFilter = searchFilter.replace("?", deletedRole);
+                        roleSearchFilter = searchFilter.replace("?", escapeSpecialCharactersForFilter(deletedRole));
                         String[] returningAttributes = new String[]{membershipAttribute};
                         String searchBase = context.getSearchBase();
                         NamingEnumeration<SearchResult> groupResults =
@@ -1302,7 +1302,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
                     String searchFilter = context.getSearchFilter();
 
                     if (isExistingRole(newRole)) {
-                        roleSearchFilter = searchFilter.replace("?", newRole);
+                        roleSearchFilter = searchFilter.replace("?", escapeSpecialCharactersForFilter(newRole));
                         String[] returningAttributes = new String[]{membershipAttribute};
                         String searchBase = context.getSearchBase();
 
@@ -1374,7 +1374,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
             DirContext mainDirContext = this.connectionSource.getContext();
 
             try {
-                searchFilter = searchFilter.replace("?", roleName);
+                searchFilter = searchFilter.replace("?", escapeSpecialCharactersForFilter(roleName));
                 String membershipAttributeName =
                         realmConfig.getUserStoreProperty(LDAPConstants.MEMBERSHIP_ATTRIBUTE);
                 String[] returningAttributes = new String[]{membershipAttributeName};
@@ -1632,7 +1632,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
 
         try {
 
-            groupSearchFilter = groupSearchFilter.replace("?", roleName);
+            groupSearchFilter = groupSearchFilter.replace("?", escapeSpecialCharactersForFilter(roleName));
             String[] returningAttributes = {roleNameAttributeName};
             groupSearchResults = searchInGroupBase(groupSearchFilter, returningAttributes,
                     SearchControls.SUBTREE_SCOPE, mainContext, searchBase);
@@ -1686,7 +1686,7 @@ public class ReadWriteLDAPUserStoreManager extends ReadOnlyLDAPUserStoreManager 
 
         String roleName = context.getRoleName();
         String groupSearchFilter = ((LDAPRoleContext) context).getSearchFilter();
-        groupSearchFilter = groupSearchFilter.replace("?", context.getRoleName());
+        groupSearchFilter = groupSearchFilter.replace("?", escapeSpecialCharactersForFilter(context.getRoleName()));
         String[] returningAttributes = {((LDAPRoleContext) context).getRoleNameProperty()};
         String searchBase = ((LDAPRoleContext) context).getSearchBase();
 


### PR DESCRIPTION
This fixes ldap injection vulnerability by escaping filter specific special characters from search filter input.