### PR TITLE
Fix NPE when downloading registry resources from Carbon console

### DIFF
--- a/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/UIBundleDeployer.java
+++ b/core/org.wso2.carbon.ui/src/main/java/org/wso2/carbon/ui/deployment/UIBundleDeployer.java
@@ -48,9 +48,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Dictionary;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.Filter;
 import javax.servlet.Servlet;
@@ -67,6 +69,7 @@ public class UIBundleDeployer implements SynchronousBundleListener {
             new BundleBasedUIResourceProvider(bundleResourcePath);
     //Used to hide the menus in the management console.
     private List<String> hideMenuIds = new ArrayList<>();
+    private Map<String, org.osgi.framework.ServiceRegistration<?>> servletRegistrations = new HashMap<>();
 
     public UIResourceProvider getBundleBasedUIResourcePrvider() {
         return bundleBasedUIResourceProvider;
@@ -290,34 +293,31 @@ public class UIBundleDeployer implements SynchronousBundleListener {
         if (component != null
                 && component.getServlets() != null
                 && component.getServlets().length > 0) {
-            HttpService httpService;
-            try {
-                httpService = CarbonUIServiceComponent.getHttpService();
-            } catch (Exception e) {
-                throw new CarbonException("An instance of HttpService is not available");
-            }
             org.wso2.carbon.ui.deployment.beans.Servlet[] servletDefinitions = component.getServlets();
             for (int a = 0; a < servletDefinitions.length; a++) {
                 org.wso2.carbon.ui.deployment.beans.Servlet servlet = servletDefinitions[a];
                 if (CarbonConstants.ADD_UI_COMPONENT.equals(action)) {
                     if (log.isTraceEnabled()) {
-                        log.trace("Registering sevlet : " + servlet);
+                        log.trace("Registering servlet : " + servlet);
                     }
                     try {
                         Class clazz = Class.forName(servlet.getServletClass());
-                        //TODO : allow servlet parameters to be passed
-                        Dictionary params = new Hashtable();
-                        httpService.registerServlet(servlet.getUrlPatten(),
-                                (Servlet) clazz.newInstance(), params,
-                                httpContext);
+                        Servlet servletInstance = (Servlet) clazz.newInstance();
+                        Dictionary<String, String> props = new Hashtable<>();
+                        props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
+                                servlet.getUrlPatten());
+                        props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
+                                "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME
+                                        + "=carbonContext)");
+                        props.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME,
+                                servlet.getName() != null ? servlet.getName()
+                                        : servlet.getServletClass());
+                        org.osgi.framework.ServiceRegistration<?> reg =
+                                bundleContext.registerService(
+                                        Servlet.class.getName(), servletInstance, props);
+                        servletRegistrations.put(servlet.getUrlPatten(), reg);
                     } catch (ClassNotFoundException e) {
                         log.error("Servlet class : " + servlet.getServletClass() + " not found.", e);
-                    } catch (ServletException e) {
-                        log.error("Problem registering Servlet class : " +
-                                servlet.getServletClass() + ".", e);
-                    } catch (NamespaceException e) {
-                        log.error("Problem registering Servlet class : " +
-                                servlet.getServletClass() + ".", e);
                     } catch (InstantiationException e) {
                         log.error("Problem registering Servlet class : " +
                                 servlet.getServletClass() + ".", e);
@@ -327,15 +327,16 @@ public class UIBundleDeployer implements SynchronousBundleListener {
                     }
                 } else if (CarbonConstants.REMOVE_UI_COMPONENT.equals(action)) {
                     if (log.isTraceEnabled()) {
-                        log.trace("Unregistering sevlet : " + servlet);
+                        log.trace("Unregistering servlet : " + servlet);
                     }
-                    httpService.unregister(servlet.getUrlPatten());
+                    org.osgi.framework.ServiceRegistration<?> reg =
+                            servletRegistrations.remove(servlet.getUrlPatten());
+                    if (reg != null) {
+                        reg.unregister();
+                    }
                 }
             }
-
         }
-
-
     }
 
     private void processCustomRegistryDefinitions(Component component, String action) throws

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/CarbonUtils.java
@@ -839,6 +839,17 @@ public class CarbonUtils {
         String carbonMgtParam = "${carbon.management.port}";
         String mgtTransport = getManagementTransport();
         String returnUrl = url;
+        if (returnUrl == null) {
+            String httpsPort =
+                    CarbonUtils.getTransportPort(configCtx, mgtTransport) + "";
+            String host = System.getProperty(ServerConstants.LOCAL_IP_ADDRESS, "localhost");
+            String context = ServerConfiguration.getInstance().getFirstProperty("WebContextRoot");
+            if (context == null || context.equals("/")) {
+                context = "";
+            }
+            returnUrl = mgtTransport + "://" + host + ":" + httpsPort + context + "/services/";
+            return returnUrl;
+        }
 		if (returnUrl.indexOf(carbonMgtParam) != -1) {
             String httpsPort =
                     CarbonUtils.getTransportPort(configCtx, mgtTransport) + "";


### PR DESCRIPTION
## Summary
- Fixes `NullPointerException: Cannot invoke "String.indexOf(String)" because "returnUrl" is null` when downloading registry resources from the Carbon Management Console
- Migrates `UIBundleDeployer` servlet registration from the old OSGi HttpService API to the HTTP Whiteboard API, ensuring component servlets share the same session context as the Carbon console JSPs
- Adds null-safety fallback in `CarbonUtils.getServerURL()` to construct a URL from server configuration when `returnUrl` is null

## Root Cause
Commit `8e4934287e` introduced a regression by moving core servlets to the OSGi HTTP Whiteboard pattern while leaving component-registered servlets (via `UIBundleDeployer`) on the old HttpService API. In Equinox, each registration mechanism creates a separate `ContextController` with its own session attribute namespace, so session attributes set during login (like `SERVER_URL`) were invisible to the ResourceServlet, causing the NPE.

## Test plan
- [x] Reproduced issue on WSO2 AM 4.7.0-SNAPSHOT — confirmed HTTP 500 with NPE stack trace
- [x] Applied patched jars and verified download returns HTTP 200 with correct content
- [x] Verified no NPE or error in server logs after fix
- [x] Tested via Playwright browser automation (login → navigate to registry resource → click Download)

Fixes: https://github.com/wso2/api-manager/issues/4848

🤖 Generated with [Claude Code](https://claude.com/claude-code)