### PR TITLE
Bump log4j version to 2.25.4

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -554,8 +554,8 @@
         <version.drools>5.1.1</version.drools>
         <version.jsr94>1.1</version.jsr94>
 
-        <version.log4j.core>2.25.3</version.log4j.core>
-        <version.log4j.jul>2.25.3</version.log4j.jul>
+        <version.log4j.core>2.25.4</version.log4j.core>
+        <version.log4j.jul>2.25.4</version.log4j.jul>
         <version.commons.logging>1.2</version.commons.logging>
         <version.xmlunit>1.1</version.xmlunit>
         <version.jaxen>1.1.1</version.jaxen>


### PR DESCRIPTION
## Purpose
Update log4j dependencies to the latest release (2.25.4) to keep carbon-kernel current.

## Related Issue
Fixes wso2/product-is#27612

## Implementation
Updated `version.log4j.core` and `version.log4j.jul` from `2.25.3` to `2.25.4` in `parent/pom.xml`.