### PR TITLE
Add the ORACLE query for `doListUsersWithID`

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java
@@ -43,6 +43,7 @@ public final class JDBCRealmConstants {
     public static final String GET_USER_FILTER_PAGINATED_WITH_ID_MSSQL = "UserFilterPaginatedWithIDSQL-mssql";
     public static final String GET_USER_FILTER_PAGINATED_DB2 = "UserFilterPaginatedSQL-db2";
     public static final String GET_USER_FILTER_PAGINATED_ORACLE = "UserFilterPaginatedSQL-oracle";
+    public static final String GET_USER_FILTER_PAGINATED_WITH_ID_ORACLE = "UserFilterPaginatedWithIDSQL-oracle";
     public static final String GET_USER_FILTER_PAGINATED_COUNT = "UserFilterPaginatedCountSQL";
     public static final String GET_USER_FILTER_PAGINATED_COUNT_WITH_ID = "UserFilterPaginatedCountWithIDSQL";
     public static final String GET_USER_ROLE = "UserRoleSQL";
@@ -227,6 +228,10 @@ public final class JDBCRealmConstants {
     public static final String GET_USER_FILTER_PAGINATED_SQL_ORACLE = "SELECT UM_USER_NAME FROM (SELECT UM_USER_NAME," +
             " UM_TENANT_ID, rownum AS rnum FROM (SELECT UM_USER_NAME, UM_TENANT_ID FROM UM_USER ORDER BY " +
             "UM_USER_NAME) WHERE UM_USER_NAME LIKE ? AND UM_TENANT_ID=? AND rownum <= ?) WHERE  rnum > ?";
+    public static final String GET_USER_FILTER_PAGINATED_WITH_USER_ID_SQL_ORACLE =
+            "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT UM_USER_ID, UM_USER_NAME, UM_TENANT_ID, rownum AS rnum "
+                    + "FROM (SELECT UM_USER_ID, UM_USER_NAME, UM_TENANT_ID FROM UM_USER ORDER BY UM_USER_NAME) "
+                    + "WHERE UM_USER_NAME LIKE ? AND UM_TENANT_ID=? AND rownum <= ?) WHERE rnum > ?";
     public static final String GET_USER_FILTER_PAGINATED_WITH_ID_SQL_ORACLE =
             "SELECT UM_USER.UM_USER_ID, UM_USER_ATTRIBUTE.UM_ATTR_VALUE FROM (SELECT UM_USER.UM_USER_ID, rownum AS "
                     + "rnum FROM (SELECT DISTINCT UM_USER.UM_USER_ID FROM UM_USER, UM_USER_ATTRIBUTE WHERE UM_USER_ATTRIBUTE"

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/caseinsensitive/JDBCCaseInsensitiveConstants.java
@@ -39,6 +39,8 @@ public class JDBCCaseInsensitiveConstants {
             "UserFilterPaginatedWithIDSQLCaseInsensitive-mssql";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_DB2 = "UserFilterPaginatedSQLCaseInsensitive-db2";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_ORACLE = "UserFilterPaginatedSQLCaseInsensitive-oracle";
+    public static final String GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_PAGINATED_ORACLE =
+            "UserFilterPaginatedWithIDSQLCaseInsensitive-oracle";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_COUNT =
             "UserFilterPaginatedSQLCaseInsensitiveCount";
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_COUNT_WITH_ID =
@@ -132,6 +134,10 @@ public class JDBCCaseInsensitiveConstants {
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_SQL_ORACLE = "SELECT UM_USER_NAME FROM " +
             "(SELECT UM_USER_NAME,UM_TENANT_ID, rownum AS rnum FROM (SELECT UM_USER_NAME, UM_TENANT_ID FROM UM_USER " +
             "ORDER BY  UM_USER_NAME) WHERE UM_USER_NAME LIKE LOWER(?) AND UM_TENANT_ID=? AND rownum <= ?) WHERE  rnum > ?";
+    public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_WITH_ID_SQL_ORACLE =
+            "SELECT UM_USER_ID, UM_USER_NAME FROM (SELECT UM_USER_ID, UM_USER_NAME, UM_TENANT_ID, rownum AS rnum "
+                    + "FROM (SELECT UM_USER_ID, UM_USER_NAME, UM_TENANT_ID FROM UM_USER ORDER BY UM_USER_NAME) "
+                    + "WHERE LOWER(UM_USER_NAME) LIKE LOWER(?) AND UM_TENANT_ID=? AND rownum <= ?) WHERE rnum > ?";
 
     public static final String GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_COUNT_SQL = "SELECT COUNT (UM_USER_NAME) " +
             "FROM UM_USER WHERE LOWER(UM_USER_NAME) LIKE LOWER(?) AND UM_TENANT_ID=?";

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/util/JDBCRealmUtil.java
@@ -151,6 +151,10 @@ public class JDBCRealmUtil {
             properties.put(JDBCRealmConstants.GET_USER_FILTER_PAGINATED_ORACLE,
                     JDBCRealmConstants.GET_USER_FILTER_PAGINATED_SQL_ORACLE);
         }
+        if (!properties.containsKey(JDBCRealmConstants.GET_USER_FILTER_PAGINATED_WITH_ID_ORACLE)) {
+            properties.put(JDBCRealmConstants.GET_USER_FILTER_PAGINATED_WITH_ID_ORACLE,
+                    JDBCRealmConstants.GET_USER_FILTER_PAGINATED_WITH_USER_ID_SQL_ORACLE);
+        }
         if (!properties.containsKey(JDBCRealmConstants.GET_USER_FILTER_PAGINATED_MSSQL)) {
             properties.put(JDBCRealmConstants.GET_USER_FILTER_PAGINATED_MSSQL,
                     JDBCRealmConstants.GET_USER_FILTER_PAGINATED_SQL_MSSQL);
@@ -712,6 +716,10 @@ public class JDBCRealmUtil {
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_ORACLE)) {
             properties.put(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_ORACLE,
                     JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_SQL_ORACLE);
+        }
+        if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_PAGINATED_ORACLE)) {
+            properties.put(JDBCCaseInsensitiveConstants.GET_USER_FILTER_WITH_ID_CASE_INSENSITIVE_PAGINATED_ORACLE,
+                    JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_WITH_ID_SQL_ORACLE);
         }
         if (!properties.containsKey(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_COUNT)) {
             properties.put(JDBCCaseInsensitiveConstants.GET_USER_FILTER_CASE_INSENSITIVE_PAGINATED_COUNT,


### PR DESCRIPTION
## Purpose
In `UniqueIDJDBCUserStoreManager`, the `doListUsersWithID` method is invoked when listing users with a username filter and pagination. Although Oracle-specific offset and limit handling has been addressed [1], there is no Oracle-specific query in the default query list. As a result, the fallback queries [2], [3] are used, which include `LIMIT` and `OFFSET` clauses that are not supported by Oracle. This PR adds the appropriate Oracle query to resolve this issue.

[1] - https://github.com/wso2/carbon-kernel/blob/4d637638b4f63212050d0cca8b0aa04afa38be78/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java#L3469-L3471
[2] - https://github.com/wso2/carbon-kernel/blob/4d637638b4f63212050d0cca8b0aa04afa38be78/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/UniqueIDJDBCUserStoreManager.java#L3476-L3478
[3] - https://github.com/wso2/carbon-kernel/blob/4d637638b4f63212050d0cca8b0aa04afa38be78/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/jdbc/JDBCRealmConstants.java#L202-L203

## Related Issue
- https://github.com/wso2/product-is/issues/27605