### PR TITLE
Bump pax-logging version to 2.2.9-wso2v3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -521,8 +521,8 @@
         <version.commons.logging>1.2</version.commons.logging>
 
         <!--PAX Logging related dependency versions-->
-        <pax.logging.api.version>2.2.9-wso2v2</pax.logging.api.version>
-        <pax.logging.log4j2.version>2.2.9-wso2v2</pax.logging.log4j2.version>
+        <pax.logging.api.version>2.2.9-wso2v3</pax.logging.api.version>
+        <pax.logging.log4j2.version>2.2.9-wso2v3</pax.logging.log4j2.version>
 
         <!--<version.opensaml2>2.4.1.wso2v1</version.opensaml2>-->
 


### PR DESCRIPTION
## Purpose
Update pax-logging dependencies (`pax-logging-api` and `pax-logging-log4j2`) from version `2.2.9-wso2v2` to `2.2.9-wso2v3`.

## Related Issue
https://github.com/wso2-enterprise/asgardeo-product/issues/35350

## Implementation
Updated the `pax.logging.api.version` and `pax.logging.log4j2.version` properties in `parent/pom.xml` from `2.2.9-wso2v2` to `2.2.9-wso2v3`.