### PR TITLE
[4.11.x] Port tomcat template configs for web portal securing

### DIFF
--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/carbon/META-INF/context.xml.j2
@@ -36,4 +36,9 @@
     <Realm className="waffle.apache.WindowsRealm"/>
     {% endif %}
 
+    {% if admin_console.control_access.enable is sameas true %}
+    <Valve className="org.apache.catalina.valves.RemoteAddrValve"
+        allow="{% for ip in admin_console.control_access.allow %}{{ip}}{{ "|" if not loop.last}}{% endfor %}"/>
+    {% endif %}
+
 </Context>

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/tomcat/web.xml.j2
@@ -116,6 +116,35 @@
     </filter-mapping>
     {% endfor %}
 
+    {% for filter in servlet_access_control_filter %}
+    <filter>
+        <filter-name>{{filter.filter_name}}</filter-name>
+        <filter-class>org.apache.catalina.filters.RemoteAddrFilter</filter-class>
+        {% if filter.allow_ip_regex is defined %}
+        <init-param>
+            <param-name>allow</param-name>
+            <param-value>{{filter.allow_ip_regex}}</param-value>
+        </init-param>
+        {% endif %}
+        {% if filter.deny_ip_regex is defined %}
+        <init-param>
+            <param-name>deny</param-name>
+            <param-value>{{filter.deny_ip_regex}}</param-value>
+        </init-param>
+        {% endif %}
+        {% if filter.deny_status is defined %}
+        <init-param>
+            <param-name>denyStatus</param-name>
+            <param-value>{{filter.deny_status}}</param-value>
+        </init-param>
+        {% endif %}
+    </filter>
+    <filter-mapping>
+        <filter-name>{{filter.filter_name}}</filter-name>
+        <url-pattern>{{filter.url_pattern}}</url-pattern>
+    </filter-mapping>
+    {% endfor %}
+
     <servlet>
         <servlet-name>default</servlet-name>
         <servlet-class>org.apache.catalina.servlets.DefaultServlet</servlet-class>


### PR DESCRIPTION
## Root cause and fix
- The tomcat template configs introduced for web portal securing (landed on 4.6.x/4.7.x in 2021) were never ported to 4.11.x, so this branch cannot render them from `deployment.toml`.
- `web.xml.j2`: adds the `servlet_access_control_filter` Jinja block, rendering an `org.apache.catalina.filters.RemoteAddrFilter` (with optional `allow`/`deny`/`denyStatus` init-params) and its filter-mapping per configured `[[servlet_access_control_filter]]` entry.
- `carbon/META-INF/context.xml.j2`: adds the `admin_console.control_access` block, rendering an `org.apache.catalina.valves.RemoteAddrValve` restricting the management console to the configured allow list.
- Both blocks render nothing when the corresponding config is absent, so default packs are unaffected.
- The third file of the source fix (top-level `tomcat/context.xml.j2`) is intentionally not included: that template was re-homed to the carbon-deployment webapp-mgt server feature (wso2/carbon-deployment#358 on its 4.11.x) which owns the `context.xml` it renders.

## Source fix
- https://github.com/wso2/carbon-kernel/pull/3107 (4.6.x)
- https://github.com/wso2/carbon-kernel/pull/3108 (4.7.x)

## Tracking issue
- https://github.com/wso2/product-apim/issues/11889