### PR TITLE
Improve group and role handling

### DIFF
--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -9161,6 +9161,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         if (rolesAndGroups != null && rolesAndGroups.length > 0) {
             finalValues.put(rolesAndGroupsClaim, getMultiValuedString(Arrays.asList(rolesAndGroups)));
+        } else {
+            finalValues.remove(rolesAndGroupsClaim);
         }
 
         if (isGroupsVsRolesSeparationImprovementsEnabled(realmConfig)) {
@@ -9174,10 +9176,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
             if (roles != null && roles.length > 0) {
                 finalValues.put(rolesClaim, getMultiValuedString(Arrays.asList(roles)));
+            } else {
+                finalValues.remove(rolesClaim);
             }
 
             if (groups != null && groups.length > 0) {
                 finalValues.put(groupsClaim, getMultiValuedString(Arrays.asList(groups)));
+            } else {
+                finalValues.remove(groupsClaim);
             }
         }
         return finalValues;

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -9161,7 +9161,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         if (rolesAndGroups != null && rolesAndGroups.length > 0) {
             finalValues.put(rolesAndGroupsClaim, getMultiValuedString(Arrays.asList(rolesAndGroups)));
-        } else {
+        } else if (isEmptyRolesAndGroupsClaimsSkipped()) {
             finalValues.remove(rolesAndGroupsClaim);
         }
 
@@ -9176,13 +9176,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
             if (roles != null && roles.length > 0) {
                 finalValues.put(rolesClaim, getMultiValuedString(Arrays.asList(roles)));
-            } else {
+            } else if (isEmptyRolesAndGroupsClaimsSkipped()) {
                 finalValues.remove(rolesClaim);
             }
 
             if (groups != null && groups.length > 0) {
                 finalValues.put(groupsClaim, getMultiValuedString(Arrays.asList(groups)));
-            } else {
+            } else if (isEmptyRolesAndGroupsClaimsSkipped()) {
                 finalValues.remove(groupsClaim);
             }
         }
@@ -13612,7 +13612,7 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         if (rolesAndGroups != null && rolesAndGroups.size() > 0) {
             finalValues.put(rolesAndGroupsClaim, getMultiValuedString(rolesAndGroups));
-        } else {
+        } else if (isEmptyRolesAndGroupsClaimsSkipped()) {
             finalValues.remove(rolesAndGroupsClaim);
         }
 
@@ -13627,13 +13627,13 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
             if (roles != null && roles.size() > 0) {
                 finalValues.put(rolesClaim, getMultiValuedString(roles));
-            } else {
+            } else if (isEmptyRolesAndGroupsClaimsSkipped()) {
                 finalValues.remove(rolesClaim);
             }
 
             if (groups != null && groups.size() > 0) {
                 finalValues.put(groupsClaim, getMultiValuedString(groups));
-            } else {
+            } else if (isEmptyRolesAndGroupsClaimsSkipped()) {
                 finalValues.remove(groupsClaim);
             }
         }
@@ -20348,5 +20348,17 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
             addToUserNameCacheOnRead(user.getUserID(), user.getUsername(), user.getUserStoreDomain());
         }
         return userList;
+    }
+
+    /**
+     * Checks whether the roles and groups claims should be excluded from the user claims when the user is not
+     * assigned to any role or group. When disabled, any previously resolved value for those claims is retained.
+     *
+     * @return True if empty roles and groups claims should be excluded from the user claims.
+     */
+    private boolean isEmptyRolesAndGroupsClaimsSkipped() {
+
+        return Boolean.parseBoolean(ServerConfiguration.getInstance()
+                .getFirstProperty(ServerConstants.SKIP_GROUP_ROLES_FROM_USER_CLAIMS));
     }
 }

--- a/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
+++ b/core/org.wso2.carbon.user.core/src/main/java/org/wso2/carbon/user/core/common/AbstractUserStoreManager.java
@@ -13606,6 +13606,8 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
         if (rolesAndGroups != null && rolesAndGroups.size() > 0) {
             finalValues.put(rolesAndGroupsClaim, getMultiValuedString(rolesAndGroups));
+        } else {
+            finalValues.remove(rolesAndGroupsClaim);
         }
 
         if (isGroupsVsRolesSeparationImprovementsEnabled(realmConfig)) {
@@ -13619,10 +13621,14 @@ public abstract class AbstractUserStoreManager implements PaginatedUserStoreMana
 
             if (roles != null && roles.size() > 0) {
                 finalValues.put(rolesClaim, getMultiValuedString(roles));
+            } else {
+                finalValues.remove(rolesClaim);
             }
 
             if (groups != null && groups.size() > 0) {
                 finalValues.put(groupsClaim, getMultiValuedString(groups));
+            } else {
+                finalValues.remove(groupsClaim);
             }
         }
         return finalValues;

--- a/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
+++ b/core/org.wso2.carbon.utils/src/main/java/org/wso2/carbon/utils/ServerConstants.java
@@ -154,6 +154,7 @@ public final class ServerConstants {
     public static final String CONFIGURATION_CONTEXT = "CONFIGURATION_CONTEXT";
     public static final String STS_NAME = "wso2carbon-sts";
     public static final String DEFAULT_PASSWORD_VALIDITY_PERIOD = "DefaultPasswordValidityPeriod";
+    public static final String SKIP_GROUP_ROLES_FROM_USER_CLAIMS = "SkipGroupRolesFromUserClaims";
 
     public static final String JCE_PROVIDER = "JCEProvider";
     public static final String JCE_PROVIDER_BC = "BC";

--- a/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
+++ b/distribution/kernel/carbon-home/repository/resources/conf/templates/repository/conf/carbon.xml.j2
@@ -870,6 +870,10 @@
     <!-- Configure password validity period for initially set password -->
     <DefaultPasswordValidityPeriod>{{password.default_validity_period}}</DefaultPasswordValidityPeriod>
 
+    <!-- Exclude the roles and groups claims from the user claims when the user is not assigned to any
+         role or group. When set to false, any previously resolved value for those claims is retained. -->
+    <SkipGroupRolesFromUserClaims>{{server.skip_group_roles_from_user_claims | default('true')}}</SkipGroupRolesFromUserClaims>
+
     <!-- Configure JCE provider -->
     {% if jce_provider.provider_name is defined %}
         <JCEProvider>{{jce_provider.provider_name}}</JCEProvider>


### PR DESCRIPTION
## Purpose
This pull request makes improvements to how user claim values are managed in the `AbstractUserStoreManager`. The main change ensures that when a user has no associated roles or groups, the corresponding claims are explicitly removed from the returned values.

Enhancements to claim value handling:

* Updated `doGetUserClaimValuesWithID` in `AbstractUserStoreManager.java` to remove the `rolesAndGroupsClaim`, `rolesClaim`, and `groupsClaim` from `finalValues` when the user has no associated roles or groups. [[1]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18R13561-R13562) [[2]](diffhunk://#diff-72ed29bb5d0219833ab12a1c431a6ba2c33003d1230c16bf4b05e0302cb4da18R13576-R13583)

### Related Issue
- https://github.com/wso2/product-is/issues/28275